### PR TITLE
Nutritional Information Screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationScreen.kt
@@ -1,0 +1,18 @@
+package com.github.se.polyfit.ui.components
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.hasTestTag
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class NutritionalInformationScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<NutritionalInformationScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("NutritionalInformation") }) {
+
+  val mealName: KNode = child { hasTestTag("MealName") }
+  val noMealInfo: KNode = child { hasTestTag("NoNutritionalInformation") }
+  val nutrient: KNode = child { hasTestTag("NutrientInfo") }
+  val nutrientName: KNode = nutrient.child { hasTestTag("NutrientName") }
+  val nutrientAmount: KNode = nutrient.child { hasTestTag("NutrientAmount") }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationTest.kt
@@ -1,0 +1,170 @@
+package com.github.se.polyfit.ui.components
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
+import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NutritionalInformationTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val onlyCalories =
+      NutritionalInformation(
+          mutableListOf(
+              Nutrient("calories", 100.0, MeasurementUnit.CAL),
+          ))
+
+  private val noCaloriesInfo =
+      NutritionalInformation(
+          mutableListOf(
+              Nutrient("totalWeight", 100.0, MeasurementUnit.G),
+              Nutrient("fat", 10.0, MeasurementUnit.G),
+              Nutrient("saturatedFat", 3.0, MeasurementUnit.G),
+              Nutrient("carbohydrates", 20.0, MeasurementUnit.G),
+          ))
+
+  private val nutritionalInformation =
+      NutritionalInformation(
+          mutableListOf(
+              Nutrient("totalWeight", 100.0, MeasurementUnit.G),
+              Nutrient("calories", 200.0, MeasurementUnit.CAL),
+              Nutrient("fat", 10.0, MeasurementUnit.G),
+              Nutrient("saturatedFat", 3.0, MeasurementUnit.G),
+              Nutrient("carbohydrates", 20.0, MeasurementUnit.G),
+              Nutrient("netCarbohydrates", 15.0, MeasurementUnit.G),
+              Nutrient("sugar", 5.0, MeasurementUnit.G),
+              Nutrient("cholesterol", 0.0, MeasurementUnit.MG),
+              Nutrient("sodium", 0.0, MeasurementUnit.MG),
+              Nutrient("protein", 15.0, MeasurementUnit.G),
+              Nutrient("vitaminC", 0.0, MeasurementUnit.MG),
+              Nutrient("manganese", 0.0, MeasurementUnit.UG),
+              Nutrient("fiber", 2.0, MeasurementUnit.G),
+              Nutrient("vitaminB6", 0.0, MeasurementUnit.MG),
+              Nutrient("copper", 0.0, MeasurementUnit.UG),
+              Nutrient("vitaminB1", 0.0, MeasurementUnit.MG),
+              Nutrient("folate", 0.0, MeasurementUnit.UG),
+              Nutrient("potassium", 0.0, MeasurementUnit.MG),
+              Nutrient("magnesium", 0.0, MeasurementUnit.MG),
+              Nutrient("vitaminB3", 0.0, MeasurementUnit.MG),
+              Nutrient("vitaminB5", 0.0, MeasurementUnit.MG),
+              Nutrient("vitaminB2", 0.0, MeasurementUnit.MG),
+              Nutrient("iron", 0.0, MeasurementUnit.MG),
+              Nutrient("calcium", 0.0, MeasurementUnit.MG),
+              Nutrient("vitaminA", 0.0, MeasurementUnit.IU),
+              Nutrient("zinc", 0.0, MeasurementUnit.MG),
+              Nutrient("phosphorus", 0.0, MeasurementUnit.MG),
+              Nutrient("vitaminK", 0.0, MeasurementUnit.UG),
+              Nutrient("selenium", 0.0, MeasurementUnit.UG),
+              Nutrient("vitaminE", 0.0, MeasurementUnit.IU)))
+
+  private fun meal(nutritionalInformation: NutritionalInformation) =
+      Meal(
+          name = "Steak & Veggie",
+          ingredients = mutableListOf(),
+          occasion = MealOccasion.DINNER,
+          mealID = 20,
+          nutritionalInformation = nutritionalInformation)
+
+  private fun setup(meal: Meal) {
+    composeTestRule.setContent { NutritionalInformation(meal = meal) }
+  }
+
+  @Test
+  fun noCaloriesAvailable() {
+    val meal = meal(noCaloriesInfo)
+    setup(meal)
+
+    ComposeScreen.onComposeScreen<NutritionalInformationScreen>(composeTestRule) {
+      noMealInfo {
+        assertIsDisplayed()
+        assertTextEquals("No nutritional information available")
+      }
+
+      mealName {
+        assertIsDisplayed()
+        assertTextEquals(meal.name)
+      }
+
+      nutrient { assertDoesNotExist() }
+      nutrientAmount { assertDoesNotExist() }
+      nutrientName { assertDoesNotExist() }
+    }
+  }
+
+  @Test
+  fun regularMeal() {
+    val meal = meal(nutritionalInformation)
+    setup(meal)
+
+    ComposeScreen.onComposeScreen<NutritionalInformationScreen>(composeTestRule) {
+      noMealInfo { assertDoesNotExist() }
+
+      mealName {
+        assertIsDisplayed()
+        assertTextEquals(meal.name)
+      }
+
+      nutrient { assertIsDisplayed() }
+
+      nutrientName {
+        assertIsDisplayed()
+        assertTextEquals("Calories")
+      }
+
+      nutrientAmount {
+        assertIsDisplayed()
+        assertTextEquals("200 cal")
+      }
+
+      val lazyCol = composeTestRule.onNodeWithTag("NutritionalInformation")
+
+      lazyCol.performScrollToIndex(meal.nutritionalInformation.nutrients.size)
+
+      composeTestRule.onNodeWithText("Vitamin E").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun onlyCalories() {
+    val meal = meal(onlyCalories)
+    setup(meal)
+
+    ComposeScreen.onComposeScreen<NutritionalInformationScreen>(composeTestRule) {
+      noMealInfo { assertDoesNotExist() }
+
+      mealName {
+        assertIsDisplayed()
+        assertTextEquals(meal.name)
+      }
+
+      nutrient { assertIsDisplayed() }
+
+      nutrientName {
+        assertIsDisplayed()
+        assertTextEquals("Calories")
+      }
+
+      nutrientAmount {
+        assertIsDisplayed()
+        assertTextEquals("100 cal")
+      }
+
+      composeTestRule.onAllNodesWithTag("NutrientInfo").assertCountEquals(1)
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
@@ -79,6 +79,7 @@ class IngredientTest : TestCase() {
       backButton {
         assertIsDisplayed()
         assertHasClickAction()
+        assertContentDescriptionEquals("Back")
         performClick()
       }
 
@@ -123,6 +124,7 @@ class IngredientTest : TestCase() {
       doneButton {
         assertIsDisplayed()
         assertHasClickAction()
+        assertTextEquals("Done")
         performClick()
       }
 
@@ -190,6 +192,7 @@ class IngredientTest : TestCase() {
       potentialIngredientButton {
         assertIsDisplayed()
         assertTextContains("Carrots")
+        assertContentDescriptionEquals("Add Carrots")
         assertHasClickAction()
       }
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationScreen.kt
@@ -1,0 +1,30 @@
+package com.github.se.polyfit.ui.screen
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class NutritionalInformationTopBar(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<NutritionalInformationTopBar>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("TopBar") }) {
+
+  val title: KNode = child { hasTestTag("Title") }
+  val backButton: KNode = child { hasTestTag("BackButton") }
+}
+
+class NutritionalInformationBottomBar(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<NutritionalInformationBottomBar>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("BottomBar") }) {
+
+  private val buttonColumn: KNode = child { hasTestTag("ButtonColumn") }
+  val addRecipeButton: KNode = buttonColumn.child { hasTestTag("AddRecipeButton") }
+  val addToDiaryButton: KNode = buttonColumn.child { hasTestTag("AddToDiaryButton") }
+}
+
+class NutritionalInformationBody(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<NutritionalInformationBody>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("NutritionalInformation") }) {
+
+  val mealName: KNode = child { hasTestTag("MealName") }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
@@ -1,0 +1,121 @@
+package com.github.se.polyfit.ui.screen
+
+import android.util.Log
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import com.github.se.polyfit.ui.navigation.Navigation
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.confirmVerified
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NutritionalInfoTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule val mockkRule = MockKRule(this)
+
+  @RelaxedMockK lateinit var mockNav: Navigation
+
+  private val meal =
+      Meal(
+          name = "Steak and frites",
+          mealID = 1,
+          nutritionalInformation = NutritionalInformation(mutableListOf()),
+          occasion = MealOccasion.LUNCH)
+
+  @Before
+  fun setup() {
+    mockkStatic(Log::class)
+    composeTestRule.setContent { NutritionScreen(meal = meal, navigation = mockNav) }
+  }
+
+  @After
+  fun tearDown() {
+    unmockkStatic(Log::class)
+  }
+
+  @Test
+  fun topBarDisplayed() {
+    ComposeScreen.onComposeScreen<NutritionalInformationTopBar>(composeTestRule) {
+      title {
+        assertIsDisplayed()
+        assertTextEquals("Nutrition Facts")
+      }
+
+      backButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertContentDescriptionEquals("Back")
+        performClick()
+      }
+
+      verify { mockNav.goBack() }
+      confirmVerified(mockNav)
+    }
+  }
+
+  @Test
+  fun addRecipeButton() {
+    ComposeScreen.onComposeScreen<NutritionalInformationBottomBar>(composeTestRule) {
+      addToDiaryButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertTextEquals("Add to Diary")
+      }
+
+      addRecipeButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertTextEquals("Add Recipe")
+        performClick()
+      }
+
+      // TODO: Update with proper test when functionality is implemented
+      verify { Log.v("Add Recipe", "Clicked") }
+    }
+  }
+
+  @Test
+  fun addToDiaryButton() {
+    ComposeScreen.onComposeScreen<NutritionalInformationBottomBar>(composeTestRule) {
+      addRecipeButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertTextEquals("Add Recipe")
+      }
+
+      addToDiaryButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertTextEquals("Add to Diary")
+        performClick()
+      }
+
+      verify { Log.v("Add to Diary", "Clicked") }
+    }
+  }
+
+  @Test
+  fun verifyBodyShown() {
+    ComposeScreen.onComposeScreen<NutritionalInformationBody>(composeTestRule) {
+      mealName {
+        assertIsDisplayed()
+        assertTextEquals(meal.name)
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/Nutrient.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/Nutrient.kt
@@ -1,6 +1,7 @@
 package com.github.se.polyfit.model.nutritionalInformation
 
 import android.util.Log
+import com.github.se.polyfit.ui.utils.titleCase
 
 data class Nutrient(val nutrientType: String, val amount: Double, val unit: MeasurementUnit) {
 
@@ -12,6 +13,24 @@ data class Nutrient(val nutrientType: String, val amount: Double, val unit: Meas
 
   fun deepCopy(): Nutrient {
     return Nutrient(nutrientType, amount, unit)
+  }
+
+  fun getFormattedName(): String {
+    return if (!isVitamin()) {
+      val regex = "(?=[A-Z])".toRegex()
+      titleCase(nutrientType.split(regex).joinToString(" "))
+    } else {
+      val vitaminType = nutrientType.substringAfter("vitamin", "")
+      titleCase("vitamin $vitaminType")
+    }
+  }
+
+  fun getFormattedAmount(): String {
+    return "${amount.toInt()} ${unit.toString().lowercase()}"
+  }
+
+  private fun isVitamin(): Boolean {
+    return nutrientType.startsWith("vitamin", ignoreCase = true)
   }
 
   override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
@@ -69,6 +69,10 @@ class NutritionalInformation {
     return newNutritionalInformation
   }
 
+  fun getNutrient(nutrientType: String): Nutrient? {
+    return nutrients.find { it.nutrientType == nutrientType }
+  }
+
   companion object {
     fun serialize(nutritionalInformation: NutritionalInformation): List<Map<String, Any>> {
       return nutritionalInformation.nutrients.map { Nutrient.serialize(it) }

--- a/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
@@ -1,0 +1,73 @@
+package com.github.se.polyfit.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
+import com.github.se.polyfit.ui.theme.PrimaryPurple
+
+@Composable
+fun NutritionalInformation(meal: Meal) {
+  val nutritionalInformation = meal.nutritionalInformation
+  val nutrients = nutritionalInformation.nutrients
+  val calories = nutritionalInformation.getNutrient("calories")
+
+  LazyColumn(modifier = Modifier.padding(16.dp, 0.dp).testTag("NutritionalInformation")) {
+    item { MealName(meal.name) }
+
+    // At the very least, a meal should always have calories
+    if (calories == null) {
+      item {
+        Text(
+            "No nutritional information available",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.testTag("NoNutritionalInformation"))
+      }
+    } else {
+      item { NutrientInfo(nutrient = calories, style = MaterialTheme.typography.bodyLarge) }
+      nutrients.forEach { nutrient ->
+        if (nutrient.nutrientType != "calories") {
+          item { NutrientInfo(nutrient = nutrient) }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun MealName(mealName: String) {
+  Column {
+    Text(
+        mealName,
+        color = PrimaryPurple,
+        style = MaterialTheme.typography.headlineSmall,
+        modifier = Modifier.testTag("MealName"))
+    HorizontalDivider()
+  }
+}
+
+@Composable
+private fun NutrientInfo(nutrient: Nutrient, style: TextStyle = MaterialTheme.typography.bodyMedium) {
+  Row(
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier = Modifier.fillMaxWidth().testTag("NutrientInfo")) {
+        Text(
+            nutrient.getFormattedName(), style = style, modifier = Modifier.testTag("NutrientName"))
+        Text(
+            nutrient.getFormattedAmount(),
+            style = style,
+            modifier = Modifier.testTag("NutrientAmount"))
+      }
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
@@ -59,7 +59,10 @@ private fun MealName(mealName: String) {
 }
 
 @Composable
-private fun NutrientInfo(nutrient: Nutrient, style: TextStyle = MaterialTheme.typography.bodyMedium) {
+private fun NutrientInfo(
+    nutrient: Nutrient,
+    style: TextStyle = MaterialTheme.typography.bodyMedium
+) {
   Row(
       horizontalArrangement = Arrangement.SpaceBetween,
       modifier = Modifier.fillMaxWidth().testTag("NutrientInfo")) {

--- a/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,9 +38,9 @@ fun NutritionalInformation(meal: Meal) {
       }
     } else {
       item { NutrientInfo(nutrient = calories, style = MaterialTheme.typography.bodyLarge) }
-      nutrients.forEach { nutrient ->
+      items(nutrients) { nutrient ->
         if (nutrient.nutrientType != "calories") {
-          item { NutrientInfo(nutrient = nutrient) }
+          NutrientInfo(nutrient = nutrient)
         }
       }
     }

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
@@ -49,7 +49,6 @@ data class Ingredient(
     val probability: Float = 1.0f,
 ) {}
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun IngredientScreen(
     navigation: Navigation,
@@ -63,40 +62,16 @@ fun IngredientScreen(
     mutableStateListOf(*initialPotentialIngredients.toTypedArray())
   }
 
-  Scaffold(
-      topBar = {
-        TopAppBar(
-            title = {
-              Text(
-                  "Ingredients",
-                  modifier = Modifier.testTag("IngredientTitle"),
-                  color = MaterialTheme.colorScheme.secondary,
-                  fontSize = MaterialTheme.typography.headlineMedium.fontSize)
-            },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigation.goBack() },
-                  content = {
-                    Icon(
-                        imageVector = Icons.Default.ArrowBack,
-                        contentDescription = "Back",
-                        modifier = Modifier.testTag("BackButton"),
-                        tint = PrimaryPurple)
-                  },
-                  modifier = Modifier.testTag("BackButton"))
-            },
-            modifier = Modifier.testTag("TopBar"))
-      },
-      bottomBar = { BottomBar() }) {
-        IngredientList(
-            it,
-            ingredients,
-            potentialIngredients,
-            onAddIngredient = { index ->
-              val item = potentialIngredients.removeAt(index)
-              ingredients.add(item)
-            })
-      }
+  Scaffold(topBar = { TopBar(navigation) }, bottomBar = { BottomBar() }) {
+    IngredientList(
+        it,
+        ingredients,
+        potentialIngredients,
+        onAddIngredient = { index ->
+          val item = potentialIngredients.removeAt(index)
+          ingredients.add(item)
+        })
+  }
 }
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -206,6 +181,32 @@ private fun BottomBar() {
               }
         }
   }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TopBar(navigation: Navigation) {
+  TopAppBar(
+      title = {
+        Text(
+            "Ingredients",
+            modifier = Modifier.testTag("IngredientTitle"),
+            color = MaterialTheme.colorScheme.secondary,
+            fontSize = MaterialTheme.typography.headlineMedium.fontSize)
+      },
+      navigationIcon = {
+        IconButton(
+            onClick = { navigation.goBack() },
+            content = {
+              Icon(
+                  imageVector = Icons.Default.ArrowBack,
+                  contentDescription = "Back",
+                  modifier = Modifier.testTag("BackButton"),
+                  tint = PrimaryPurple)
+            },
+            modifier = Modifier.testTag("BackButton"))
+      },
+      modifier = Modifier.testTag("TopBar"))
 }
 
 // Comment out increases coverage...

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
@@ -15,8 +15,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -199,7 +199,7 @@ private fun TopBar(navigation: Navigation) {
             onClick = { navigation.goBack() },
             content = {
               Icon(
-                  imageVector = Icons.Default.ArrowBack,
+                  imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                   contentDescription = "Back",
                   modifier = Modifier.testTag("BackButton"),
                   tint = PrimaryPurple)
@@ -209,7 +209,6 @@ private fun TopBar(navigation: Navigation) {
       modifier = Modifier.testTag("TopBar"))
 }
 
-// Comment out increases coverage...
 // @Preview
 // @Composable
 // fun IngredientScreenPreview() {

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
@@ -173,7 +173,7 @@ fun IngredientList(
 }
 
 @Composable
-fun BottomBar() {
+private fun BottomBar() {
   Column(
       modifier =
           Modifier.background(MaterialTheme.colorScheme.background)

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
@@ -1,0 +1,100 @@
+package com.github.se.polyfit.ui.screen
+
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.ui.components.NutritionalInformation
+import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.ui.theme.PrimaryPink
+import com.github.se.polyfit.ui.theme.PrimaryPurple
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NutritionScreen(meal: Meal, navigation: Navigation) {
+  Scaffold(topBar = { TopBar(navigation = navigation) }, bottomBar = { BottomBar() }) { innerPadding
+    ->
+    Box(modifier = Modifier.padding(innerPadding)) { NutritionalInformation(meal = meal) }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TopBar(navigation: Navigation) {
+  TopAppBar(
+      title = {
+        Text(
+            "Nutrition Facts",
+            modifier = Modifier.testTag("Title"),
+            color = MaterialTheme.colorScheme.secondary,
+            style = MaterialTheme.typography.headlineMedium)
+      },
+      navigationIcon = {
+        IconButton(
+            onClick = { navigation.goBack() },
+            content = {
+              Icon(
+                  imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                  contentDescription = "Back",
+                  modifier = Modifier.testTag("BackButton"),
+                  tint = PrimaryPurple)
+            },
+            modifier = Modifier.testTag("BackButton"))
+      },
+      modifier = Modifier.testTag("TopBar"))
+}
+
+@Composable
+private fun BottomBar() {
+  BottomAppBar(
+      modifier = Modifier.height(128.dp).testTag("BottomBar"), containerColor = Color.Transparent) {
+        Column(
+            modifier = Modifier.fillMaxWidth().testTag("ButtonColumn"),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Button(
+                  onClick = { Log.v("Add Recipe", "Clicked") },
+                  colors =
+                      ButtonDefaults.buttonColors(
+                          containerColor = PrimaryPink,
+                          contentColor = MaterialTheme.colorScheme.onPrimary),
+                  modifier = Modifier.width(250.dp).testTag("AddRecipeButton"),
+              ) {
+                Text(text = "Add Recipe", style = MaterialTheme.typography.bodyLarge)
+              }
+              Spacer(modifier = Modifier.height(8.dp))
+              Button(
+                  onClick = { Log.v("Add to Diary", "Clicked") },
+                  colors =
+                      ButtonDefaults.buttonColors(
+                          containerColor = PrimaryPurple,
+                          contentColor = MaterialTheme.colorScheme.onPrimary),
+                  modifier = Modifier.width(250.dp).testTag("AddToDiaryButton"),
+              ) {
+                Text(text = "Add to Diary", style = MaterialTheme.typography.bodyLarge)
+              }
+            }
+      }
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/utils/StringUtils.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/utils/StringUtils.kt
@@ -1,0 +1,8 @@
+package com.github.se.polyfit.ui.utils
+
+fun titleCase(input: String): String {
+  return input.split(" ").joinToString(" ") { word ->
+    val smallCaseWord = word.lowercase()
+    smallCaseWord.replaceFirstChar(Char::titlecaseChar)
+  }
+}

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutrientTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutrientTest.kt
@@ -69,4 +69,30 @@ class NutrientTest {
       Nutrient.deserialize(mapOf("amount" to 100.0, "unit" to "INVALID"))
     }
   }
+
+  @Test
+  fun `get formatted amount shows properly`() {
+    val nutrientGrams = Nutrient("fats", 100.0, MeasurementUnit.G)
+    val nutrientCalories = Nutrient("calories", 100.2421, MeasurementUnit.CAL)
+    Assert.assertEquals("100 g", nutrientGrams.getFormattedAmount())
+    Assert.assertEquals("100 cal", nutrientCalories.getFormattedAmount())
+  }
+
+  @Test
+  fun `get formatted name show properly for one word name`() {
+    val nutrient = Nutrient("fats", 100.0, MeasurementUnit.G)
+    Assert.assertEquals("Fats", nutrient.getFormattedName())
+  }
+
+  @Test
+  fun `get formatted name shows properly for multiple word name`() {
+    val nutrient = Nutrient("saturatedFats", 100.0, MeasurementUnit.G)
+    Assert.assertEquals("Saturated Fats", nutrient.getFormattedName())
+  }
+
+  @Test
+  fun `get formatted name shows properly for vitamin`() {
+    val nutrient = Nutrient("vitaminb4", 100.0, MeasurementUnit.IU)
+    Assert.assertEquals("Vitamin B4", nutrient.getFormattedName())
+  }
 }

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
@@ -271,4 +271,16 @@ class NutritionalInformationTest {
 
     assertEquals(nutritionalInformation1.hashCode(), nutritionalInformation2.hashCode())
   }
+
+  @Test
+  fun `getNutrient returns the correct nutrient`() {
+    val nutrient = nutritionalInformation.getNutrient("totalWeight")
+    assertEquals(Nutrient("totalWeight", 100.0, MeasurementUnit.G), nutrient)
+  }
+
+  @Test
+  fun `getNutrient returns null if nutrient does not exist`() {
+    val nutrient = nutritionalInformation.getNutrient("nonExistentNutrient")
+    assertEquals(null, nutrient)
+  }
 }

--- a/app/src/test/java/com/github/se/polyfit/ui/utils/StringUtilsTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/ui/utils/StringUtilsTest.kt
@@ -1,0 +1,39 @@
+package com.github.se.polyfit.utils
+
+import com.github.se.polyfit.ui.utils.titleCase
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class StringUtilsTest {
+  @Test
+  fun titleCaseSingleLower() {
+    val input = "hello"
+    val expected = "Hello"
+    val actual = titleCase(input)
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun titleCaseSingleUpper() {
+    val input = "HELLO"
+    val expected = "Hello"
+    val actual = titleCase(input)
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun titleCaseMultipleWords() {
+    val input = "hello world"
+    val expected = "Hello World"
+    val actual = titleCase(input)
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun titleCaseMultipleWordsWithSpaces() {
+    val input = "hello   world"
+    val expected = "Hello   World"
+    val actual = titleCase(input)
+    assertEquals(expected, actual)
+  }
+}


### PR DESCRIPTION
Adding UI support to [display nutritional information](https://github.com/orgs/swent-group10/projects/2?pane=issue&itemId=57702252).

- Takes in a Meal, and displays the title and nutrition facts for all ingredients. 
- Buttons to save to diary or add recipe, easy to hookup when that functionality is ready
- no title editing for now, but also easy to add when we are ready to support that functionality

<img width="315" alt="image" src="https://github.com/swent-group10/polyfit/assets/68757340/e3b2f765-2896-41ed-9c76-58e890df6176">