### PR TITLE
Fixes issues with checking if login intent was sent

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/LoginTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/LoginTest.kt
@@ -15,58 +15,64 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class LoginTest : TestCase() {
-  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
 
-  @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+    @get:Rule
+    val intentsTestRule = IntentsTestRule(MainActivity::class.java)
 
-  @Test
-  fun titleAndButtonAreCorrectlyDisplayed() {
-    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
-      // Test the UI elements
-      loginTitle {
-        assertIsDisplayed()
-        assertTextEquals("PolyFit")
-      }
-      loginButton {
-        assertIsDisplayed()
-        assertHasClickAction()
-      }
+    @Test
+    fun titleAndButtonAreCorrectlyDisplayed() {
+        ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+            // Test the UI elements
+            loginTitle {
+                assertIsDisplayed()
+                assertTextEquals("PolyFit")
+            }
+            loginButton {
+                assertIsDisplayed()
+                assertHasClickAction()
+            }
 
-      loginTerm {
-        assertIsDisplayed()
-        assertTextContains(
-            "By clicking continue, you agree to our", substring = true, ignoreCase = false)
-        assertTextContains("Terms of Service", substring = true, ignoreCase = false)
-        assertTextContains("Privacy Policy", substring = true, ignoreCase = false)
-      }
+            loginTerm {
+                assertIsDisplayed()
+                assertTextContains(
+                    "By clicking continue, you agree to our", substring = true, ignoreCase = false
+                )
+                assertTextContains("Terms of Service", substring = true, ignoreCase = false)
+                assertTextContains("Privacy Policy", substring = true, ignoreCase = false)
+            }
+        }
     }
-  }
 
-  @Test
-  fun loginButtonNavigatesToNewScreen() {
-    // Launch the LoginScreen
-    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
-      // Test the UI elements
-      loginButton {
-        assertIsDisplayed()
-        assertHasClickAction()
-        performClick()
-      }
-      // TODO check we are on another page
-      intended(toPackage("com.google.android.gms"))
+    @Test
+    fun loginButtonNavigatesToNewScreen() {
+        // Launch the LoginScreen
+        ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+            // Test the UI elements
+            loginButton {
+                assertIsDisplayed()
+                assertHasClickAction()
+                performClick()
+            }
+            // TODO check we are on another page
+            intended(toPackage("com.google.android.gms"))
+        }
     }
-  }
 
-  @Test
-  fun googleSignInReturnsValidActivityResult() {
-    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
-      loginButton {
-        assertIsDisplayed()
-        performClick()
-      }
+    @Test
+    fun googleSignInReturnsValidActivityResult() {
+        // Wait for the Compose UI to be idle before proceeding with the test
+        composeTestRule.waitForIdle()
 
-      // assert that an Intent resolving to Google Mobile Services has been sent (for sign-in)
-      intended(hasComponent("com.google.android.gms.auth.api.signin.internal.SignInHubActivity"))
+        ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+            loginButton {
+                assertIsDisplayed()
+                performClick()
+            }
+
+            // assert that an Intent resolving to Google Mobile Services has been sent (for sign-in)
+            intended(hasComponent("com.google.android.gms.auth.api.signin.internal.SignInHubActivity"))
+        }
     }
-  }
 }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/LoginTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/LoginTest.kt
@@ -15,64 +15,61 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class LoginTest : TestCase() {
-    @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
 
-    @get:Rule
-    val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+  @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java)
 
-    @Test
-    fun titleAndButtonAreCorrectlyDisplayed() {
-        ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
-            // Test the UI elements
-            loginTitle {
-                assertIsDisplayed()
-                assertTextEquals("PolyFit")
-            }
-            loginButton {
-                assertIsDisplayed()
-                assertHasClickAction()
-            }
+  @Test
+  fun titleAndButtonAreCorrectlyDisplayed() {
+    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+      // Test the UI elements
+      loginTitle {
+        assertIsDisplayed()
+        assertTextEquals("PolyFit")
+      }
+      loginButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
 
-            loginTerm {
-                assertIsDisplayed()
-                assertTextContains(
-                    "By clicking continue, you agree to our", substring = true, ignoreCase = false
-                )
-                assertTextContains("Terms of Service", substring = true, ignoreCase = false)
-                assertTextContains("Privacy Policy", substring = true, ignoreCase = false)
-            }
-        }
+      loginTerm {
+        assertIsDisplayed()
+        assertTextContains(
+            "By clicking continue, you agree to our", substring = true, ignoreCase = false)
+        assertTextContains("Terms of Service", substring = true, ignoreCase = false)
+        assertTextContains("Privacy Policy", substring = true, ignoreCase = false)
+      }
     }
+  }
 
-    @Test
-    fun loginButtonNavigatesToNewScreen() {
-        // Launch the LoginScreen
-        ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
-            // Test the UI elements
-            loginButton {
-                assertIsDisplayed()
-                assertHasClickAction()
-                performClick()
-            }
-            // TODO check we are on another page
-            intended(toPackage("com.google.android.gms"))
-        }
+  @Test
+  fun loginButtonNavigatesToNewScreen() {
+    // Launch the LoginScreen
+    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+      // Test the UI elements
+      loginButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        performClick()
+      }
+      // TODO check we are on another page
+      intended(toPackage("com.google.android.gms"))
     }
+  }
 
-    @Test
-    fun googleSignInReturnsValidActivityResult() {
-        // Wait for the Compose UI to be idle before proceeding with the test
-        composeTestRule.waitForIdle()
+  @Test
+  fun googleSignInReturnsValidActivityResult() {
+    // Wait for the Compose UI to be idle before proceeding with the test
+    composeTestRule.waitForIdle()
 
-        ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
-            loginButton {
-                assertIsDisplayed()
-                performClick()
-            }
+    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+      loginButton {
+        assertIsDisplayed()
+        performClick()
+      }
 
-            // assert that an Intent resolving to Google Mobile Services has been sent (for sign-in)
-            intended(hasComponent("com.google.android.gms.auth.api.signin.internal.SignInHubActivity"))
-        }
+      // assert that an Intent resolving to Google Mobile Services has been sent (for sign-in)
+      intended(hasComponent("com.google.android.gms.auth.api.signin.internal.SignInHubActivity"))
     }
+  }
 }


### PR DESCRIPTION
## Summary

This pull request addresses a failing test case in the `LoginTest` class, specifically the `googleSignInReturnsValidActivityResult` test. The test was failing due to an `IllegalStateException` indicating that no compose hierarchies were found in the app.

### Issue and Root Cause

The test failed with an `IllegalStateException`, suggesting issues with `setContent` related operations. It was determined that conditions were not properly initialized, and Compose UI elements were not stabilized before the test ran.

### Implemented Solution

The issue has been resolved by implementing a waiting mechanism that ensures all elements are stabilized before the test is executed.
