### PR TITLE
MealViewModel & UI Integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,7 @@ android {
         implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
         implementation("androidx.activity:activity-compose:1.8.2")
         implementation(platform("androidx.compose:compose-bom:2024.04.00"))
+        implementation("androidx.compose.runtime:runtime-livedata:1.1.0")
         implementation("androidx.compose.ui:ui")
         implementation("androidx.compose.ui:ui-graphics")
         implementation("androidx.compose.ui:ui-tooling-preview")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -176,6 +176,8 @@ android {
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
         testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.0")
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.9.0")
+        testImplementation("org.robolectric:robolectric:4.8")
+
         // Hilts
         implementation("com.google.dagger:hilt-android:2.51")
         annotationProcessor("com.google.dagger:hilt-compiler:2.51")

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/AddIngredientPopupTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/AddIngredientPopupTest.kt
@@ -36,7 +36,9 @@ class AddIngredientPopupTest : TestCase() {
   @Before
   fun setup() {
     mockkStatic(Log::class)
-    composeTestRule.setContent { AddIngredientDialog(onClickCloseDialog = {}) }
+    composeTestRule.setContent {
+      AddIngredientDialog(onAddIngredient = {}, onClickCloseDialog = {})
+    }
   }
 
   @After

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/AddIngredientPopupTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/AddIngredientPopupTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyPress
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -68,9 +69,14 @@ class AddIngredientPopupTest : TestCase() {
 
       // Search bar input
       composeTestRule
-          .onNodeWithText("Find an Ingredient...") // find based on placeholder
+          .onNodeWithText("Enter an Ingredient...") // find based on placeholder
           .assertExists("Placeholder text is not found.")
           .performTextInput("a")
+
+      composeTestRule
+          .onNodeWithTag("SearchIcon")
+          .assertExists("Search icon is not found.")
+          .performClick()
 
       searchResultContainer {
         assertIsDisplayed()
@@ -86,7 +92,7 @@ class AddIngredientPopupTest : TestCase() {
     ComposeScreen.onComposeScreen<AddIngredientSearchBar>(composeTestRule) {
       // Search bar input
       composeTestRule
-          .onNodeWithText("Find an Ingredient...") // find based on placeholder
+          .onNodeWithText("Enter an Ingredient...") // find based on placeholder
           .performTextInput("apple")
 
       composeTestRule
@@ -94,6 +100,11 @@ class AddIngredientPopupTest : TestCase() {
           .performKeyPress(KeyEvent(NativeKeyEvent(0, 66))) // 66 is the keycode for 'Enter' key
 
       verify { Log.v("Search", "Searching for apple") }
+
+      composeTestRule
+          .onNodeWithTag("SearchIcon")
+          .assertExists("Search icon is not found.")
+          .performClick()
 
       singleSearchResult {
         assertIsDisplayed()
@@ -108,26 +119,28 @@ class AddIngredientPopupTest : TestCase() {
     }
   }
 
+  // TODO: after writing data retrieval from database for ingredient, write test for it
+
   @Test
   fun nutritionInfoIsDisplayed() {
     ComposeScreen.onComposeScreen<AddIngredientEditNutritionInfo>(composeTestRule) {
       servingSizeContainer { assertIsDisplayed() }
-      carloiesContainer { assertIsDisplayed() }
+      caloriesContainer { assertIsDisplayed() }
       carbsContainer { assertIsDisplayed() }
       fatContainer { assertIsDisplayed() }
       proteinContainer { assertIsDisplayed() }
 
       servingSizeLabel {
         assertIsDisplayed()
-        assertTextContains("Serving Size")
+        assertTextContains("Total Weight")
       }
-      carloiesLabel {
+      caloriesLabel {
         assertIsDisplayed()
         assertTextContains("Calories")
       }
       carbsLabel {
         assertIsDisplayed()
-        assertTextContains("Carbs")
+        assertTextContains("Carbohydrates")
       }
       fatLabel {
         assertIsDisplayed()
@@ -140,47 +153,52 @@ class AddIngredientPopupTest : TestCase() {
 
       servingSizeInput {
         assertIsDisplayed()
-        assertTextContains("0")
+        assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        assertTextContains("1")
+        performImeAction()
+        assertTextContains("1.0")
       }
-      carloiesInput {
+      caloriesInput {
         assertIsDisplayed()
-        assertTextContains("0")
+        assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
         assertTextContains("1")
       }
       carbsInput {
         assertIsDisplayed()
-        assertTextContains("0")
+        assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        assertTextContains("1")
+        performImeAction()
+        assertTextContains("1.0")
       }
+      caloriesInput { assertTextContains("1.0") }
       fatInput {
         assertIsDisplayed()
-        assertTextContains("0")
+        assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        assertTextContains("1")
+        performImeAction()
+        assertTextContains("1.0")
       }
       proteinInput {
         assertIsDisplayed()
-        assertTextContains("0")
+        assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        assertTextContains("1")
+        performImeAction()
+        assertTextContains("1.0")
       }
 
       servingSizeUnit {
         assertIsDisplayed()
         assertTextContains("g")
       }
-      carloiesUnit {
+      caloriesUnit {
         assertIsDisplayed()
-        assertTextContains("kcal")
+        assertTextContains("cal")
       }
       carbsUnit {
         assertIsDisplayed()
@@ -205,6 +223,25 @@ class AddIngredientPopupTest : TestCase() {
         assertTextContains("Add")
         assertHasClickAction()
       }
+    }
+  }
+
+  @Test
+  fun addButtonIsConditionallyDisabled() {
+    ComposeScreen.onComposeScreen<AddIngredientButton>(composeTestRule) {
+      addIngredientButton {
+        assertIsDisplayed()
+        assertTextContains("Add")
+        assertIsNotEnabled()
+      }
+
+      composeTestRule.onNodeWithText("Enter an Ingredient...").performTextInput("apple")
+
+      composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performTextInput("1")
+
+      composeTestRule.onNodeWithTag("NutritionSizeInput Calories").performTextInput("1")
+
+      addIngredientButton { assertIsEnabled() }
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/AddIngredientScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/AddIngredientScreen.kt
@@ -31,30 +31,30 @@ class AddIngredientEditNutritionInfo(semanticsProvider: SemanticsNodeInteraction
         semanticsProvider = semanticsProvider,
         viewBuilderAction = { hasTestTag("AddIngredientContentContainer") }) {
 
-  val servingSizeContainer: KNode = child { hasTestTag("NutritionInfoContainer Serving Size") }
-  val carloiesContainer: KNode = child { hasTestTag("NutritionInfoContainer Calories") }
-  val carbsContainer: KNode = child { hasTestTag("NutritionInfoContainer Carbs") }
+  val servingSizeContainer: KNode = child { hasTestTag("NutritionInfoContainer Total Weight") }
+  val caloriesContainer: KNode = child { hasTestTag("NutritionInfoContainer Calories") }
+  val carbsContainer: KNode = child { hasTestTag("NutritionInfoContainer Carbohydrates") }
   val fatContainer: KNode = child { hasTestTag("NutritionInfoContainer Fat") }
   val proteinContainer: KNode = child { hasTestTag("NutritionInfoContainer Protein") }
 
   val servingSizeLabel: KNode =
-      servingSizeContainer.child { hasTestTag("NutritionLabel Serving Size") }
-  val carloiesLabel: KNode = carloiesContainer.child { hasTestTag("NutritionLabel Calories") }
-  val carbsLabel: KNode = carbsContainer.child { hasTestTag("NutritionLabel Carbs") }
+      servingSizeContainer.child { hasTestTag("NutritionLabel Total Weight") }
+  val caloriesLabel: KNode = caloriesContainer.child { hasTestTag("NutritionLabel Calories") }
+  val carbsLabel: KNode = carbsContainer.child { hasTestTag("NutritionLabel Carbohydrates") }
   val fatLabel: KNode = fatContainer.child { hasTestTag("NutritionLabel Fat") }
   val proteinLabel: KNode = proteinContainer.child { hasTestTag("NutritionLabel Protein") }
 
   val servingSizeInput: KNode =
-      servingSizeContainer.child { hasTestTag("NutritionSizeInput Serving Size") }
-  val carloiesInput: KNode = carloiesContainer.child { hasTestTag("NutritionSizeInput Calories") }
-  val carbsInput: KNode = carbsContainer.child { hasTestTag("NutritionSizeInput Carbs") }
+      servingSizeContainer.child { hasTestTag("NutritionSizeInput Total Weight") }
+  val caloriesInput: KNode = caloriesContainer.child { hasTestTag("NutritionSizeInput Calories") }
+  val carbsInput: KNode = carbsContainer.child { hasTestTag("NutritionSizeInput Carbohydrates") }
   val fatInput: KNode = fatContainer.child { hasTestTag("NutritionSizeInput Fat") }
   val proteinInput: KNode = proteinContainer.child { hasTestTag("NutritionSizeInput Protein") }
 
   val servingSizeUnit: KNode =
-      servingSizeContainer.child { hasTestTag("NutritionUnit Serving Size") }
-  val carloiesUnit: KNode = carloiesContainer.child { hasTestTag("NutritionUnit Calories") }
-  val carbsUnit: KNode = carbsContainer.child { hasTestTag("NutritionUnit Carbs") }
+      servingSizeContainer.child { hasTestTag("NutritionUnit Total Weight") }
+  val caloriesUnit: KNode = caloriesContainer.child { hasTestTag("NutritionUnit Calories") }
+  val carbsUnit: KNode = carbsContainer.child { hasTestTag("NutritionUnit Carbohydrates") }
   val fatUnit: KNode = fatContainer.child { hasTestTag("NutritionUnit Fat") }
   val proteinUnit: KNode = proteinContainer.child { hasTestTag("NutritionUnit Protein") }
 }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationTest.kt
@@ -83,7 +83,7 @@ class NutritionalInformationTest : TestCase() {
 
   private fun setup(meal: Meal) {
     composeTestRule.setContent {
-      NutritionalInformation(mealViewModel = MealViewModel(userID = "testUserID", meal = meal))
+      NutritionalInformation(mealViewModel = MealViewModel("testUserID", initialMeal = meal))
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/NutritionalInformationTest.kt
@@ -13,6 +13,7 @@ import com.github.se.polyfit.model.meal.MealOccasion
 import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
 import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import com.github.se.polyfit.viewmodel.meal.MealViewModel
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import org.junit.Rule
@@ -81,7 +82,9 @@ class NutritionalInformationTest : TestCase() {
           nutritionalInformation = nutritionalInformation)
 
   private fun setup(meal: Meal) {
-    composeTestRule.setContent { NutritionalInformation(meal = meal) }
+    composeTestRule.setContent {
+      NutritionalInformation(mealViewModel = MealViewModel(userID = "testUserID", meal = meal))
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/PrimaryPurpleButtonTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/PrimaryPurpleButtonTest.kt
@@ -3,6 +3,7 @@ package com.github.se.polyfit.ui.components
 import android.util.Log
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChild
 import androidx.compose.ui.test.onNodeWithTag
@@ -47,6 +48,17 @@ class PrimaryPurpleButtonTest : TestCase() {
     ComposeScreen.onComposeScreen<GradientBox>(composeTestRule) {
       composeTestRule.onNodeWithTag("PrimaryPurpleButton").assertIsDisplayed()
       composeTestRule.onNodeWithTag("PrimaryPurpleButton").onChild().assertDoesNotExist()
+    }
+  }
+
+  @Test
+  fun disabledButton() {
+    composeTestRule.setContent {
+      PrimaryPurpleButton(onClick = {}, text = "Disabled Button", isEnabled = false)
+    }
+    ComposeScreen.onComposeScreen<GradientBox>(composeTestRule) {
+      composeTestRule.onNodeWithTag("PrimaryPurpleButton").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("PrimaryPurpleButton").assertIsNotEnabled()
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
@@ -1,0 +1,74 @@
+package com.github.se.polyfit.ui.flow
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.ui.screen.IngredientsBottomBar
+import com.github.se.polyfit.ui.screen.IngredientsList
+import com.github.se.polyfit.ui.screen.IngredientsTopBar
+import com.github.se.polyfit.ui.screen.NutritionalInformationTopBar
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.confirmVerified
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddMealFlowTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule val mockkRule = MockKRule(this)
+
+  @RelaxedMockK lateinit var mockNav: Navigation
+
+  @Before
+  fun setup() {
+    composeTestRule.setContent { AddMealFlow(mockNav, "testUserID") }
+  }
+
+  @Test
+  fun IngredientScreenIsShown() {
+    ComposeScreen.onComposeScreen<IngredientsTopBar>(composeTestRule) {
+      ingredientTitle {
+        assertIsDisplayed()
+        assertTextEquals("Ingredients")
+      }
+
+      backButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertContentDescriptionEquals("Back")
+        performClick()
+      }
+
+      verify { mockNav.goBack() }
+      confirmVerified(mockNav)
+    }
+    ComposeScreen.onComposeScreen<IngredientsList>(composeTestRule) {
+      ingredientButton { assertDoesNotExist() }
+    }
+  }
+
+  @Test
+  fun NutritionScreenIsShown() {
+    ComposeScreen.onComposeScreen<IngredientsBottomBar>(composeTestRule) {
+      doneButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertTextEquals("Done")
+        performClick()
+      }
+    }
+
+    ComposeScreen.onComposeScreen<NutritionalInformationTopBar>(composeTestRule) {
+      title {
+        assertIsDisplayed()
+        assertTextEquals("Nutrition Facts")
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
@@ -1,17 +1,19 @@
 package com.github.se.polyfit.ui.flow
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.ui.navigation.Route
+import com.github.se.polyfit.ui.screen.HomeScreen
 import com.github.se.polyfit.ui.screen.IngredientsBottomBar
 import com.github.se.polyfit.ui.screen.IngredientsList
 import com.github.se.polyfit.ui.screen.IngredientsTopBar
 import com.github.se.polyfit.ui.screen.NutritionalInformationTopBar
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import io.mockk.confirmVerified
-import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
-import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -23,11 +25,19 @@ class AddMealFlowTest {
 
   @get:Rule val mockkRule = MockKRule(this)
 
-  @RelaxedMockK lateinit var mockNav: Navigation
-
   @Before
   fun setup() {
-    composeTestRule.setContent { AddMealFlow(mockNav, "testUserID") }
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigation = Navigation(navController)
+      NavHost(navController = navController, startDestination = Route.Home) {
+        composable(Route.Home) { HomeScreen() }
+        composable(Route.AddMeal) {
+          AddMealFlow(navigation::goBack, navigation::navigateToHome, "testUserID")
+        }
+      }
+      navigation.navigateToAddMeal()
+    }
   }
 
   @Test
@@ -45,9 +55,10 @@ class AddMealFlowTest {
         performClick()
       }
 
-      verify { mockNav.goBack() }
-      confirmVerified(mockNav)
+      ingredientTitle { assertDoesNotExist() }
+      backButton { assertDoesNotExist() }
     }
+
     ComposeScreen.onComposeScreen<IngredientsList>(composeTestRule) {
       ingredientButton { assertDoesNotExist() }
     }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
@@ -45,6 +45,14 @@ class NavigationTest {
     verify { navHostController.navigate(Route.Home) }
   }
 
+  fun navigateToAddMeal() {
+    route = Route.AddMeal
+    every { navHostController.navigate(route) } returns Unit
+    navigation.navigateToAddMeal()
+
+    verify { navHostController.navigate(Route.AddMeal) }
+  }
+
   @Test
   fun navigateToNutrition() {
     route = Route.Nutrition

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
@@ -1,0 +1,56 @@
+package com.github.se.polyfit.ui.navigation
+
+import android.util.Log
+import androidx.navigation.NavHostController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NavigationTest {
+  private val navHostController: NavHostController = mockk()
+  private val navigation = Navigation(navHostController)
+  lateinit var route: String
+
+  @Before
+  fun setup() {
+    mockkStatic(Log::class)
+    every { navHostController.popBackStack() } returns true
+  }
+
+  @After
+  fun teardown() {
+    unmockkStatic(Log::class)
+  }
+
+  @Test
+  fun goBack() {
+    navigation.goBack()
+    verify { navHostController.popBackStack() }
+  }
+
+  @Test
+  fun navigateToHome() {
+    route = Route.Home
+    every { navHostController.navigate(route) } returns Unit
+    navigation.navigateToHome()
+
+    verify { navHostController.navigate(Route.Home) }
+  }
+
+  @Test
+  fun navigateToNutrition() {
+    route = Route.Nutrition
+    every { navHostController.navigate(route) } returns Unit
+    navigation.navigateToNutrition()
+
+    verify { navHostController.navigate(Route.Nutrition) }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
@@ -63,7 +63,7 @@ class IngredientTest : TestCase() {
     val navigateForward = { mockNav.navigateToNutrition() }
     val testMeal =
         Meal(
-            occasion = MealOccasion.NONE,
+            occasion = MealOccasion.OTHER,
             name = "Test Meal",
             mealID = 0,
             ingredients = testIngredients,

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
@@ -4,6 +4,10 @@ import android.util.Log
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
@@ -14,10 +18,12 @@ import com.github.se.polyfit.ui.navigation.Navigation
 import com.github.se.polyfit.viewmodel.meal.MealViewModel
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.just
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
@@ -41,6 +47,7 @@ class IngredientTest : TestCase() {
   @Before
   fun setup() {
     mockkStatic(Log::class)
+    every { mockMealViewModel.addIngredient(any()) } just Runs
   }
 
   @After
@@ -160,6 +167,8 @@ class IngredientTest : TestCase() {
     ComposeScreen.onComposeScreen<AddIngredientPopupBox>(composeTestRule) {
       addIngredientDialog { assertDoesNotExist() }
 
+      ingredientButton { assertDoesNotExist() }
+
       addIngredientGradientButton {
         assertIsDisplayed()
         assertHasClickAction()
@@ -168,13 +177,22 @@ class IngredientTest : TestCase() {
 
       addIngredientDialog { assertIsDisplayed() }
 
+      composeTestRule.onNodeWithText("Enter an Ingredient...").performTextInput("apple")
+
+      composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performTextInput("1")
+
+      composeTestRule.onNodeWithTag("NutritionSizeInput Calories").performTextInput("1")
+
       finishAddIngredientButton {
         assertIsDisplayed()
         assertHasClickAction()
         performClick()
       }
 
-      // TODO: Check that ingredient is properly added to the ingredient list
+      verify {
+        mockMealViewModel.addIngredient(
+            match { it.name == "apple" && it.amount == 10.0 && it.unit == MeasurementUnit.G })
+      }
 
       addIngredientDialog { assertDoesNotExist() }
     }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
@@ -4,13 +4,18 @@ import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.viewmodel.meal.MealViewModel
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.mockk.confirmVerified
+import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockkStatic
@@ -29,18 +34,35 @@ class NutritionalInfoTest : TestCase() {
   @get:Rule val mockkRule = MockKRule(this)
 
   @RelaxedMockK lateinit var mockNav: Navigation
+  @RelaxedMockK lateinit var mockMealViewModel: MealViewModel
 
   private val meal =
       Meal(
           name = "Steak and frites",
           mealID = 1,
-          nutritionalInformation = NutritionalInformation(mutableListOf()),
+          ingredients =
+              mutableListOf(
+                  Ingredient(
+                      "Steak",
+                      1,
+                      100.0,
+                      MeasurementUnit.G,
+                      NutritionalInformation(
+                          mutableListOf(Nutrient("Calories", 1000.0, MeasurementUnit.CAL))))),
+          nutritionalInformation =
+              NutritionalInformation(
+                  mutableListOf(Nutrient("Calories", 1000.0, MeasurementUnit.CAL))),
           occasion = MealOccasion.LUNCH)
 
   @Before
   fun setup() {
     mockkStatic(Log::class)
-    composeTestRule.setContent { NutritionScreen(meal = meal, navigation = mockNav) }
+
+    every { mockMealViewModel.meal.value } returns meal
+    val navigateBack = { mockNav.goBack() }
+    val navigateForward = { mockNav.navigateToHome() }
+
+    composeTestRule.setContent { NutritionScreen(mockMealViewModel, navigateBack, navigateForward) }
   }
 
   @After
@@ -105,7 +127,7 @@ class NutritionalInfoTest : TestCase() {
         performClick()
       }
 
-      verify { Log.v("Add to Diary", "Clicked") }
+      verify { mockNav.navigateToHome() }
     }
   }
 
@@ -118,4 +140,6 @@ class NutritionalInfoTest : TestCase() {
       }
     }
   }
+
+  // TODO: Test that incomplete meal can not be added to diary
 }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/SelectIngredientsScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/SelectIngredientsScreen.kt
@@ -31,6 +31,10 @@ class AddIngredientPopupBox(semanticsProvider: SemanticsNodeInteractionsProvider
         semanticsProvider = semanticsProvider,
         viewBuilderAction = { hasTestTag("AddIngredientScaffold") }) {
 
+  private val ingredientsList: KNode = child { hasTestTag("IngredientsList") }
+  private val ingredient: KNode = ingredientsList.child { hasTestTag("Ingredient") }
+  val ingredientButton: KNode = ingredient.child { hasTestTag("GradientButton") }
+
   private val bottomBar: KNode = child { hasTestTag("BottomBar") }
   private val addIngredientBox: KNode = bottomBar.child { hasTestTag("AddIngredientBox") }
   val addIngredientButton: KNode = addIngredientBox.child { hasTestTag("AddIngredientButton") }

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
@@ -1,0 +1,9 @@
+// package com.github.se.polyfit.viewmodel.meal
+//
+// import androidx.test.ext.junit.runners.AndroidJUnit4
+// import org.junit.runner.RunWith
+//
+// @RunWith(AndroidJUnit4::class)
+// class MealViewModelTest {
+//  // TODO: Add Tests
+// }

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
@@ -1,9 +1,0 @@
-// package com.github.se.polyfit.viewmodel.meal
-//
-// import androidx.test.ext.junit.runners.AndroidJUnit4
-// import org.junit.runner.RunWith
-//
-// @RunWith(AndroidJUnit4::class)
-// class MealViewModelTest {
-//  // TODO: Add Tests
-// }

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
       PolyfitTheme {
         val navController = rememberNavController()
         val navigation = Navigation(navController)
-        NavHost(navController = navController, startDestination = Route.AddMeal) {
+        NavHost(navController = navController, startDestination = Route.Register) {
           composable(Route.Register) { LoginScreen(navigation::navigateToHome) }
           composable(Route.Home) { HomeScreen() }
           composable(Route.AddMeal) {

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -29,7 +29,10 @@ class MainActivity : ComponentActivity() {
           composable(Route.Register) { LoginScreen(navigation::navigateToHome) }
           composable(Route.Home) { HomeScreen() }
           composable(Route.AddMeal) {
-            AddMealFlow(mainNavigation = navigation, userID = "testUserID") // TODO: real userID
+            AddMealFlow(
+                navigation::goBack,
+                navigation::navigateToHome,
+                userID = "testUserID") // TODO: real userID
           }
         }
       }

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.github.se.polyfit.ui.flow.AddMealFlow
 import com.github.se.polyfit.ui.navigation.Navigation
 import com.github.se.polyfit.ui.navigation.Route
 import com.github.se.polyfit.ui.screen.HomeScreen
@@ -24,9 +25,12 @@ class MainActivity : ComponentActivity() {
       PolyfitTheme {
         val navController = rememberNavController()
         val navigation = Navigation(navController)
-        NavHost(navController = navController, startDestination = Route.Register) {
+        NavHost(navController = navController, startDestination = Route.AddMeal) {
           composable(Route.Register) { LoginScreen(navigation::navigateToHome) }
           composable(Route.Home) { HomeScreen() }
+          composable(Route.AddMeal) {
+            AddMealFlow(mainNavigation = navigation, userID = "testUserID") // TODO: real userID
+          }
         }
       }
     }

--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -114,5 +114,16 @@ data class Meal(
         throw IllegalArgumentException("Failed to deserialize Meal object", e)
       }
     }
+
+    fun default(): Meal {
+      return Meal(
+          MealOccasion.OTHER,
+          "",
+          0,
+          20.0,
+          NutritionalInformation(mutableListOf()),
+          mutableListOf(),
+          "")
+    }
   }
 }

--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -53,6 +53,12 @@ data class Meal(
     updateMeal()
   }
 
+  fun isComplete(): Boolean {
+    return name.isNotEmpty() &&
+        ingredients.isNotEmpty() &&
+        nutritionalInformation.nutrients.isNotEmpty()
+  }
+
   private fun updateMeal() {
 
     var newNutritionalInformation = NutritionalInformation(mutableListOf())

--- a/app/src/main/java/com/github/se/polyfit/model/meal/MealOccasion.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/MealOccasion.kt
@@ -4,7 +4,8 @@ enum class MealOccasion {
   BREAKFAST,
   LUNCH,
   DINNER,
-  SNACK;
+  SNACK,
+  NONE;
 
   companion object {
     fun fromString(value: String): MealOccasion {
@@ -13,6 +14,7 @@ enum class MealOccasion {
         "LUNCH" -> LUNCH
         "DINNER" -> DINNER
         "SNACK" -> SNACK
+        "NONE" -> NONE
         else -> throw IllegalArgumentException("Invalid value for MealOccasion")
       }
     }

--- a/app/src/main/java/com/github/se/polyfit/model/meal/MealOccasion.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/MealOccasion.kt
@@ -5,7 +5,7 @@ enum class MealOccasion {
   LUNCH,
   DINNER,
   SNACK,
-  NONE;
+  OTHER;
 
   companion object {
     fun fromString(value: String): MealOccasion {
@@ -14,7 +14,7 @@ enum class MealOccasion {
         "LUNCH" -> LUNCH
         "DINNER" -> DINNER
         "SNACK" -> SNACK
-        "NONE" -> NONE
+        "OTHER" -> OTHER
         else -> throw IllegalArgumentException("Invalid value for MealOccasion")
       }
     }

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/Nutrient.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/Nutrient.kt
@@ -49,6 +49,10 @@ data class Nutrient(val nutrientType: String, val amount: Double, val unit: Meas
     return result
   }
 
+  operator fun times(factor: Double): Nutrient {
+    return Nutrient(nutrientType, amount * factor, unit)
+  }
+
   companion object {
     fun serialize(nutrient: Nutrient): Map<String, Any> {
       val map = mutableMapOf<String, Any>()

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
@@ -69,6 +69,7 @@ class NutritionalInformation {
     return newNutritionalInformation
   }
 
+  // TODO: Prevent negative values
   operator fun minus(other: NutritionalInformation): NutritionalInformation {
     val newNutritionalInformation = NutritionalInformation(mutableListOf())
 

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
@@ -69,8 +69,17 @@ class NutritionalInformation {
     return newNutritionalInformation
   }
 
+  operator fun minus(other: NutritionalInformation): NutritionalInformation {
+    val newNutritionalInformation = NutritionalInformation(mutableListOf())
+
+    nutrients.forEach { newNutritionalInformation.update(it) }
+    other.nutrients.forEach { newNutritionalInformation.update(it * -1.0) }
+
+    return newNutritionalInformation
+  }
+
   fun getNutrient(nutrientType: String): Nutrient? {
-    return nutrients.find { it.nutrientType == nutrientType }
+    return nutrients.find { it.nutrientType.lowercase() == nutrientType.lowercase() }
   }
 
   companion object {

--- a/app/src/main/java/com/github/se/polyfit/ui/components/AddIngredientPopup.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/AddIngredientPopup.kt
@@ -32,7 +32,7 @@ import com.github.se.polyfit.ui.utils.removeLeadingZerosAndNonDigits
 
 // Constants
 // Temporary list of available ingredient to search
-val TMP_AVAILABLE_INGREDIENT = listOf("Apple", "Banana", "Carrot", "Date", "Eggplant", "apes")
+val TMP_AVAILABLE_INGREDIENT = listOf("Apple", "Banana", "Carrot", "Date", "Eggplant", "Apes")
 
 @Composable
 fun AddIngredientDialog(

--- a/app/src/main/java/com/github/se/polyfit/ui/components/AddIngredientPopup.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/AddIngredientPopup.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.ui.theme.*
 import com.github.se.polyfit.ui.utils.removeLeadingZerosAndNonDigits
 
@@ -148,7 +149,7 @@ fun SearchIngredients() {
 // }
 
 @Composable
-fun AddIngredientDialog(onClickCloseDialog: () -> Unit) {
+fun AddIngredientDialog(onClickCloseDialog: () -> Unit, onAddIngredient: (Ingredient) -> Unit) {
   Dialog(onDismissRequest = onClickCloseDialog) {
     GradientBox(
         outerModifier = Modifier.testTag("AddIngredientPopupContainer"),

--- a/app/src/main/java/com/github/se/polyfit/ui/components/AddIngredientPopup.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/AddIngredientPopup.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
@@ -13,143 +15,45 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.ui.theme.*
 import com.github.se.polyfit.ui.utils.removeLeadingZerosAndNonDigits
 
 // Constants
-// Add to list for new nutrition fields
-val NUTRITION_LABELS = listOf("Serving Size", "Calories", "Carbs", "Fat", "Protein")
-val NUTRITION_UNITS = listOf("g", "kcal", "g", "g", "g")
 // Temporary list of available ingredient to search
 val TMP_AVAILABLE_INGREDIENT = listOf("Apple", "Banana", "Carrot", "Date", "Eggplant", "apes")
 
 @Composable
-fun EditIngredientNutrition(
-    // TODO: pass in viewmodel for editing specific ingredient's nutrition info
+fun AddIngredientDialog(
+    onClickCloseDialog: () -> Unit = {},
+    onAddIngredient: (Ingredient) -> Unit = {}
 ) {
-
   // TODO: currently the implementation hardcodes the field we want for quick editing the nutrition
   // info of an ingredient. This should be changed in the future depend on how we integrate the
   // ingredient info in a meal.
-  val nutritionLabels = NUTRITION_LABELS
-  val nutritionUnit = NUTRITION_UNITS
-  val nutritionSize = remember { mutableStateListOf("0", "0", "0", "0", "0") }
 
-  // TODO: when integrating with viewmodel, can be wrapped into a data class for cleaner code, for
-  // now we are using indexing to access the three hardcoded list above.
-  val nutritionLabelCount = nutritionLabels.size - 1
-  (0..nutritionLabelCount).forEach { index ->
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier =
-            Modifier.testTag("NutritionInfoContainer " + nutritionLabels[index])
-                .fillMaxWidth()
-                .padding(start = 20.dp, end = 0.dp)) {
-          Text(
-              text = nutritionLabels[index],
-              color = SecondaryGrey,
-              style = TextStyle(fontSize = 18.sp),
-              modifier = Modifier.testTag("NutritionLabel " + nutritionLabels[index]).weight(1.5f))
-
-          TextField(
-              value = nutritionSize[index],
-              onValueChange = { newValue ->
-                nutritionSize[index] = removeLeadingZerosAndNonDigits(newValue)
-              },
-              modifier =
-                  Modifier.testTag("NutritionSizeInput " + nutritionLabels[index]).weight(0.5f),
-              singleLine = true,
-              colors =
-                  TextFieldDefaults.colors(
-                      focusedIndicatorColor = PrimaryPurple,
-                      unfocusedIndicatorColor = SecondaryGrey,
-                      focusedContainerColor = Color.Transparent,
-                      unfocusedContainerColor = Color.Transparent))
-
-          Text(
-              text = nutritionUnit[index],
-              style = TextStyle(fontSize = 18.sp),
-              color = SecondaryGrey,
-              modifier =
-                  Modifier.testTag("NutritionUnit " + nutritionLabels[index])
-                      .weight(0.4f)
-                      .padding(start = 8.dp))
-        }
-    Spacer(modifier = Modifier.height(10.dp))
+  val nutritionFields = remember {
+    mutableStateListOf<Nutrient>(
+        Nutrient("totalWeight", 0.0, MeasurementUnit.G),
+        Nutrient("calories", 0.0, MeasurementUnit.CAL),
+        Nutrient("carbohydrates", 0.0, MeasurementUnit.G),
+        Nutrient("fat", 0.0, MeasurementUnit.G),
+        Nutrient("protein", 0.0, MeasurementUnit.G))
   }
-}
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun SearchIngredients() {
   var searchText by remember { mutableStateOf("") }
 
-  val showIngredientSearch = remember { mutableStateOf(false) }
-
-  // TODO: change list of ingredients to search for here
-  val ingredientDatabase = TMP_AVAILABLE_INGREDIENT
-
-  // TODO: (Optional) filter ingredients here or at backend
-  val filteredIngredients =
-      remember(searchText) {
-        ingredientDatabase.filter { it.contains(searchText, ignoreCase = true) }
-      }
-
-  SearchBar(
-      modifier = Modifier.padding(start = 20.dp, end = 20.dp).testTag("SearchIngredientBar"),
-      query = searchText,
-      onQueryChange = { searchText = it },
-      onSearch = { Log.v("Search", "Searching for $searchText") },
-      active = showIngredientSearch.value,
-      onActiveChange = { showIngredientSearch.value = true },
-      leadingIcon = {
-        Icon(Icons.Filled.Search, contentDescription = "search", tint = SecondaryGrey)
-      },
-      placeholder = {
-        Text(
-            text = "Find an Ingredient...",
-            color = SecondaryGrey,
-            style = TextStyle(fontSize = 17.sp))
-      }) {
-        LazyColumn(modifier = Modifier.testTag("IngredientSearchScrollableList")) {
-          items(filteredIngredients) { ingredient ->
-            Text(
-                text = ingredient,
-                modifier =
-                    Modifier.testTag("SearchResult $ingredient")
-                        .fillMaxWidth()
-                        .clickable {
-                          searchText = ingredient
-                          showIngredientSearch.value = false
-                          // TODO: Apply according nutrition facts to nutrition text fields
-                        }
-                        .padding(8.dp))
-            Divider()
-          }
-        }
-      }
-}
-
-// @Composable
-// fun AddButton(onClick: () -> Unit, modifier: Modifier) {
-//  Button(
-//      onClick = onClick,
-//      modifier = modifier.padding(top = 16.dp).fillMaxWidth(0.5f),
-//      shape = RoundedCornerShape(50.dp),
-//      colors = ButtonDefaults.buttonColors(containerColor = PrimaryPurple)) {
-//        Text("Add", color = Color.White)
-//      }
-// }
-
-@Composable
-fun AddIngredientDialog(onClickCloseDialog: () -> Unit, onAddIngredient: (Ingredient) -> Unit) {
   Dialog(onDismissRequest = onClickCloseDialog) {
     GradientBox(
         outerModifier = Modifier.testTag("AddIngredientPopupContainer"),
@@ -166,22 +70,158 @@ fun AddIngredientDialog(onClickCloseDialog: () -> Unit, onAddIngredient: (Ingred
                   .testTag("AddIngredientContentContainer")) {
             Spacer(modifier = Modifier.height(16.dp))
 
-            SearchIngredients()
+            SearchIngredients(searchText = searchText, onSearchTextChanged = { searchText = it })
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            EditIngredientNutrition()
+            EditIngredientNutrition(nutritionFields)
 
             PrimaryPurpleButton(
                 onClick = {
-                  // TODO: Add ingredient to ingredient list
+                  onAddIngredient(
+                      Ingredient(
+                          name = searchText,
+                          id = 0, // TODO: might need changing on how we handle the id
+                          amount = nutritionFields[0].amount,
+                          unit = nutritionFields[0].unit,
+                          nutritionalInformation =
+                              com.github.se.polyfit.model.nutritionalInformation
+                                  .NutritionalInformation(nutritionFields.toMutableList())))
                   onClickCloseDialog()
                 },
                 modifier = Modifier.padding(top = 16.dp).align(Alignment.CenterHorizontally),
-                text = "Add")
+                text = "Add",
+                isEnabled = searchText.isNotBlank() && nutritionFields[0].amount > 0.0)
           }
     }
   }
+}
+
+@Composable
+fun EditIngredientNutrition(nutritionFields: MutableList<Nutrient>) {
+
+  nutritionFields.forEachIndexed { index, nutrient ->
+    var isFocused by remember { mutableStateOf(false) }
+    var text by remember { mutableStateOf(nutrient.amount.toString()) }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier.testTag("NutritionInfoContainer " + nutrient.getFormattedName())
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 0.dp)) {
+          Text(
+              text = nutrient.getFormattedName(),
+              color = SecondaryGrey,
+              style = TextStyle(fontSize = 18.sp),
+              modifier =
+                  Modifier.testTag("NutritionLabel " + nutrient.getFormattedName()).weight(1.5f))
+
+          TextField(
+              keyboardOptions =
+                  KeyboardOptions(
+                      keyboardType = KeyboardType.Decimal,
+                      imeAction = ImeAction.Done,
+                  ),
+              keyboardActions =
+                  KeyboardActions(
+                      onDone = {
+                        try {
+                          text = removeLeadingZerosAndNonDigits(text)
+                          nutritionFields[index] = nutrient.copy(amount = text.toDouble())
+                          text = text.toDouble().toString()
+                        } catch (e: NumberFormatException) {}
+                      }),
+              value = text,
+              onValueChange = { newValue -> text = newValue },
+              modifier =
+                  Modifier.testTag("NutritionSizeInput " + nutrient.getFormattedName())
+                      .weight(0.5f)
+                      .onFocusChanged { focusState ->
+                        isFocused = focusState.isFocused
+                        if (!isFocused) { // When the TextField loses focus
+                          try {
+                            text = removeLeadingZerosAndNonDigits(text)
+                            nutritionFields[index] = nutrient.copy(amount = text.toDouble())
+                            text = text.toDouble().toString()
+                          } catch (e: NumberFormatException) {}
+                        }
+                      },
+              singleLine = true,
+              colors =
+                  TextFieldDefaults.colors(
+                      focusedIndicatorColor = PrimaryPurple,
+                      unfocusedIndicatorColor = SecondaryGrey,
+                      focusedContainerColor = Color.Transparent,
+                      unfocusedContainerColor = Color.Transparent))
+
+          // TODO: in the future, make it possible to choose between different units
+          Text(
+              text = nutrient.unit.toString().lowercase(),
+              style = TextStyle(fontSize = 18.sp),
+              color = SecondaryGrey,
+              modifier =
+                  Modifier.testTag("NutritionUnit " + nutrient.getFormattedName())
+                      .weight(0.4f)
+                      .padding(start = 8.dp))
+        }
+    Spacer(modifier = Modifier.height(10.dp))
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchIngredients(searchText: String = "", onSearchTextChanged: (String) -> Unit = {}) {
+  val showIngredientSearch = remember { mutableStateOf(false) }
+
+  // TODO: change list of ingredients to search for here
+  val ingredientDatabase = TMP_AVAILABLE_INGREDIENT
+
+  // TODO: (Optional) filter ingredients here or at backend
+  val filteredIngredients =
+      remember(searchText) {
+        ingredientDatabase.filter { it.contains(searchText, ignoreCase = true) }
+      }
+
+  SearchBar(
+      modifier = Modifier.padding(start = 20.dp, end = 20.dp).testTag("SearchIngredientBar"),
+      query = searchText,
+      onQueryChange = onSearchTextChanged,
+      onSearch = {
+        Log.v("Search", "Searching for $searchText")
+        showIngredientSearch.value = false
+      },
+      active = showIngredientSearch.value,
+      onActiveChange = {},
+      trailingIcon = {
+        IconButton(
+            modifier = Modifier.testTag("SearchIcon"),
+            onClick = { showIngredientSearch.value = true }) {
+              Icon(Icons.Filled.Search, contentDescription = "search", tint = SecondaryGrey)
+            }
+      },
+      placeholder = {
+        Text(
+            text = "Enter an Ingredient...",
+            color = SecondaryGrey,
+            style = TextStyle(fontSize = 17.sp))
+      }) {
+        LazyColumn(modifier = Modifier.testTag("IngredientSearchScrollableList")) {
+          items(filteredIngredients) { ingredient ->
+            Text(
+                text = ingredient,
+                modifier =
+                    Modifier.testTag("SearchResult $ingredient")
+                        .fillMaxWidth()
+                        .clickable {
+                          onSearchTextChanged(ingredient)
+                          showIngredientSearch.value = false
+                          // TODO: Apply according nutrition facts to nutrition text fields
+                        }
+                        .padding(8.dp))
+            Divider()
+          }
+        }
+      }
 }
 
 // Function for previewing the popup page

--- a/app/src/main/java/com/github/se/polyfit/ui/components/IngredientList.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/IngredientList.kt
@@ -25,21 +25,25 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun IngredientList(
     it: PaddingValues,
-    ingredients: List<Ingredient>,
-    potentialIngredients: List<Ingredient>,
-    onAddIngredient: (Int) -> Unit,
+    mealViewModel: MealViewModel,
 ) {
+  val ingredients = mealViewModel.meal.value?.ingredients ?: emptyList()
 
+  // TODO: Implement potential ingredients
+  val potentialIngredients = listOf<Ingredient>()
+  val onAddIngredient = { index: Int -> Log.v("Add Ingredient", "Clicked") }
   val initialSuggestions = 3
   val potentialIndex = remember {
     // equivalent to min(3, potentialIngredients.size)
     mutableIntStateOf(initialSuggestions.coerceAtMost(potentialIngredients.size))
   }
+
   Column(
       modifier =
           Modifier.fillMaxSize()
@@ -50,7 +54,7 @@ fun IngredientList(
       horizontalAlignment = Alignment.CenterHorizontally) {
         if (ingredients.isEmpty() && potentialIngredients.isEmpty()) {
           Text(
-              "No ingredients added yet",
+              "No ingredients added.",
               modifier = Modifier.fillMaxSize().padding(16.dp, 0.dp).testTag("NoIngredients"),
               color = MaterialTheme.colorScheme.secondary,
               fontSize = MaterialTheme.typography.headlineSmall.fontSize)

--- a/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/NutritionalInformation.kt
@@ -15,12 +15,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.ui.theme.PrimaryPurple
+import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @Composable
-fun NutritionalInformation(meal: Meal) {
+fun NutritionalInformation(mealViewModel: MealViewModel) {
+  val meal = mealViewModel.meal.value!!
   val nutritionalInformation = meal.nutritionalInformation
   val nutrients = nutritionalInformation.nutrients
   val calories = nutritionalInformation.getNutrient("calories")
@@ -39,7 +40,7 @@ fun NutritionalInformation(meal: Meal) {
     } else {
       item { NutrientInfo(nutrient = calories, style = MaterialTheme.typography.bodyLarge) }
       items(nutrients) { nutrient ->
-        if (nutrient.nutrientType != "calories") {
+        if (nutrient != calories) {
           NutrientInfo(nutrient = nutrient)
         }
       }
@@ -55,7 +56,7 @@ private fun MealName(mealName: String) {
         color = PrimaryPurple,
         style = MaterialTheme.typography.headlineSmall,
         modifier = Modifier.testTag("MealName"))
-    HorizontalDivider()
+    HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
   }
 }
 

--- a/app/src/main/java/com/github/se/polyfit/ui/components/PrimaryPurpleButton.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/PrimaryPurpleButton.kt
@@ -17,10 +17,12 @@ import com.github.se.polyfit.ui.theme.PrimaryPurple
 fun PrimaryPurpleButton(
     onClick: () -> Unit = {},
     modifier: Modifier = Modifier,
-    text: String = ""
+    text: String = "",
+    isEnabled: Boolean = true
 ) {
   Button(
       onClick = onClick,
+      enabled = isEnabled,
       modifier = modifier.fillMaxWidth(0.5f).testTag("PrimaryPurpleButton"),
       shape = RoundedCornerShape(50.dp),
       colors = ButtonDefaults.buttonColors(containerColor = PrimaryPurple)) {

--- a/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
@@ -11,10 +11,13 @@ import com.github.se.polyfit.ui.screen.NutritionScreen
 import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @Composable
-fun AddMealFlow(mainNavigation: Navigation, userID: String) {
+fun AddMealFlow(
+    mainNavigation: Navigation,
+    userID: String,
+    mealViewModel: MealViewModel = MealViewModel(userID)
+) {
   val navController = rememberNavController()
   val navigation = Navigation(navController)
-  val mealViewModel = MealViewModel(userID)
 
   NavHost(navController = navController, startDestination = Route.Ingredients) {
     composable(Route.Ingredients) {

--- a/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
@@ -12,7 +12,8 @@ import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @Composable
 fun AddMealFlow(
-    mainNavigation: Navigation,
+    goBack: () -> Unit,
+    navigateToHome: () -> Unit,
     userID: String,
     mealViewModel: MealViewModel = MealViewModel(userID)
 ) {
@@ -23,14 +24,14 @@ fun AddMealFlow(
     composable(Route.Ingredients) {
       IngredientScreen(
           mealViewModel = mealViewModel,
-          navigateBack = { mainNavigation.goBack() },
-          navigateForward = { navigation.navigateToNutrition() })
+          navigateBack = { goBack() },
+          navigateForward = navigation::navigateToNutrition)
     }
     composable(Route.Nutrition) {
       NutritionScreen(
           mealViewModel = mealViewModel,
           navigateBack = { navigation.goBack() },
-          navigateForward = { mainNavigation.navigateToHome() })
+          navigateForward = { navigateToHome() })
     }
   }
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
@@ -1,0 +1,33 @@
+package com.github.se.polyfit.ui.flow
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.ui.navigation.Route
+import com.github.se.polyfit.ui.screen.IngredientScreen
+import com.github.se.polyfit.ui.screen.NutritionScreen
+import com.github.se.polyfit.viewmodel.meal.MealViewModel
+
+@Composable
+fun AddMealFlow(mainNavigation: Navigation, userID: String) {
+  val navController = rememberNavController()
+  val navigation = Navigation(navController)
+  val mealViewModel = MealViewModel(userID)
+
+  NavHost(navController = navController, startDestination = Route.Ingredients) {
+    composable(Route.Ingredients) {
+      IngredientScreen(
+          mealViewModel = mealViewModel,
+          navigateBack = { mainNavigation.goBack() },
+          navigateForward = { navigation.navigateToNutrition() })
+    }
+    composable(Route.Nutrition) {
+      NutritionScreen(
+          mealViewModel = mealViewModel,
+          navigateBack = { navigation.goBack() },
+          navigateForward = { mainNavigation.navigateToHome() })
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
@@ -16,6 +16,10 @@ class Navigation(private val navHostController: NavHostController) {
     navigateTo(Route.Nutrition)
   }
 
+  fun navigateToAddMeal() {
+    navigateTo(Route.AddMeal)
+  }
+
   private fun navigateTo(route: String) {
     Log.i("Navigation", "Navigating to $route")
     navHostController.navigate(route)

--- a/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
@@ -12,6 +12,10 @@ class Navigation(private val navHostController: NavHostController) {
     navigateTo(Route.Home)
   }
 
+  fun navigateToNutrition() {
+    navigateTo(Route.Nutrition)
+  }
+
   private fun navigateTo(route: String) {
     Log.i("Navigation", "Navigating to $route")
     navHostController.navigate(route)

--- a/app/src/main/java/com/github/se/polyfit/ui/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/navigation/Route.kt
@@ -3,5 +3,9 @@ package com.github.se.polyfit.ui.navigation
 object Route {
   const val Home = "Home"
   const val Register = "Register"
+  const val AddMeal = "AddMeal"
+
+  // Add Meal Routes
   const val Ingredients = "Ingredients"
+  const val Nutrition = "Nutrition"
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -29,50 +28,39 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.ui.components.AddIngredientDialog
 import com.github.se.polyfit.ui.components.GradientButton
 import com.github.se.polyfit.ui.components.IngredientList
-import com.github.se.polyfit.ui.navigation.Navigation
 import com.github.se.polyfit.ui.theme.PrimaryPurple
-
-// TODO: Replace with real data class
+import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @Composable
 fun IngredientScreen(
-    navigation: Navigation,
-    initialIngredients: List<Ingredient>,
-    initialPotentialIngredients: List<Ingredient>,
-    // TODO:  ingredientsViewModel: IngredientsViewModel = IngredientsViewModel(),
+    mealViewModel: MealViewModel,
+    navigateBack: () -> Unit,
+    navigateForward: () -> Unit
 ) {
 
-  val ingredients = remember { mutableStateListOf(*initialIngredients.toTypedArray()) }
-  val potentialIngredients = remember {
-    mutableStateListOf(*initialPotentialIngredients.toTypedArray())
-  }
   val showAddIngredDialog = remember { mutableStateOf(false) }
 
   Scaffold(
-      topBar = { TopBar(navigation) },
-      bottomBar = { BottomBar(onClickAddIngred = { showAddIngredDialog.value = true }) }) {
-        IngredientList(
-            it,
-            ingredients,
-            potentialIngredients,
-            onAddIngredient = { index ->
-              val item = potentialIngredients.removeAt(index)
-              ingredients.add(item)
-            })
+      topBar = { TopBar(navigateBack) },
+      bottomBar = {
+        BottomBar(
+            onClickAddIngred = { showAddIngredDialog.value = true },
+            navigateForward = navigateForward)
+      }) {
+        IngredientList(it, mealViewModel)
         if (showAddIngredDialog.value) {
-          AddIngredientDialog(onClickCloseDialog = { showAddIngredDialog.value = false })
+          AddIngredientDialog(
+              onClickCloseDialog = { showAddIngredDialog.value = false },
+              onAddIngredient = mealViewModel::addIngredient)
         }
       }
 }
 
 @Composable
-private fun BottomBar(
-    onClickAddIngred: () -> Unit,
-) {
+private fun BottomBar(onClickAddIngred: () -> Unit, navigateForward: () -> Unit) {
   Column(
       modifier =
           Modifier.background(MaterialTheme.colorScheme.background)
@@ -101,7 +89,10 @@ private fun BottomBar(
         modifier = Modifier.fillMaxWidth().testTag("DoneBox"),
         contentAlignment = Alignment.Center) {
           Button(
-              onClick = { Log.v("Finished", "Clicked") }, // TODO: Finish adding ingredients
+              onClick = {
+                navigateForward()
+                Log.v("Finished", "Clicked")
+              },
               modifier = Modifier.width(200.dp).testTag("DoneButton"),
               colors = ButtonDefaults.buttonColors(containerColor = PrimaryPurple)) {
                 Text(text = "Done", fontSize = 24.sp)
@@ -112,7 +103,7 @@ private fun BottomBar(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun TopBar(navigation: Navigation) {
+private fun TopBar(navigateBack: () -> Unit) {
   TopAppBar(
       title = {
         Text(
@@ -123,7 +114,7 @@ private fun TopBar(navigation: Navigation) {
       },
       navigationIcon = {
         IconButton(
-            onClick = { navigation.goBack() },
+            onClick = { navigateBack() },
             content = {
               Icon(
                   imageVector = Icons.AutoMirrored.Filled.ArrowBack,

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
@@ -21,29 +21,42 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.ui.components.NutritionalInformation
-import com.github.se.polyfit.ui.navigation.Navigation
 import com.github.se.polyfit.ui.theme.PrimaryPink
 import com.github.se.polyfit.ui.theme.PrimaryPurple
+import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NutritionScreen(meal: Meal, navigation: Navigation) {
-  Scaffold(topBar = { TopBar(navigation = navigation) }, bottomBar = { BottomBar() }) { innerPadding
-    ->
-    Box(modifier = Modifier.padding(innerPadding)) { NutritionalInformation(meal = meal) }
-  }
+fun NutritionScreen(
+    mealViewModel: MealViewModel,
+    navigateBack: () -> Unit,
+    navigateForward: () -> Unit
+) {
+  val meal = mealViewModel.meal.observeAsState().value
+  val isComplete = meal?.isComplete() ?: false
+
+  Scaffold(
+      topBar = { TopBar(navigateBack = navigateBack) },
+      bottomBar = {
+        BottomBar(
+            setMeal = mealViewModel::setMeal,
+            isComplete = isComplete,
+            navigateForward = navigateForward)
+      }) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) { NutritionalInformation(mealViewModel) }
+      }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun TopBar(navigation: Navigation) {
+private fun TopBar(navigateBack: () -> Unit) {
   TopAppBar(
       title = {
         Text(
@@ -54,7 +67,7 @@ private fun TopBar(navigation: Navigation) {
       },
       navigationIcon = {
         IconButton(
-            onClick = { navigation.goBack() },
+            onClick = { navigateBack() },
             content = {
               Icon(
                   imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -68,7 +81,7 @@ private fun TopBar(navigation: Navigation) {
 }
 
 @Composable
-private fun BottomBar() {
+private fun BottomBar(setMeal: () -> Unit, isComplete: Boolean, navigateForward: () -> Unit) {
   BottomAppBar(
       modifier = Modifier.height(128.dp).testTag("BottomBar"), containerColor = Color.Transparent) {
         Column(
@@ -86,15 +99,19 @@ private fun BottomBar() {
               }
               Spacer(modifier = Modifier.height(8.dp))
               Button(
-                  onClick = { Log.v("Add to Diary", "Clicked") },
+                  onClick = {
+                    Log.v("Add to Diary", "Clicked")
+                    setMeal()
+                    navigateForward()
+                  },
                   colors =
                       ButtonDefaults.buttonColors(
                           containerColor = PrimaryPurple,
                           contentColor = MaterialTheme.colorScheme.onPrimary),
                   modifier = Modifier.width(250.dp).testTag("AddToDiaryButton"),
-              ) {
-                Text(text = "Add to Diary", style = MaterialTheme.typography.bodyLarge)
-              }
+                  enabled = isComplete) {
+                    Text(text = "Add to Diary", style = MaterialTheme.typography.bodyLarge)
+                  }
             }
       }
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/utils/StringUtils.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/utils/StringUtils.kt
@@ -1,12 +1,32 @@
 package com.github.se.polyfit.ui.utils
 
 fun removeLeadingZerosAndNonDigits(input: String): String {
-  val onlyDigits = input.replace(Regex("[^\\d]"), "")
+  // Remove all non-digits and non-dot characters, preserving the first dot encountered
+  var dotFound = false
+  val filteredInput =
+      input.filter { char ->
+        when {
+          char.isDigit() -> true
+          char == '.' && !dotFound -> {
+            dotFound = true
+            true
+          }
+          else -> false
+        }
+      }
 
-  return if (onlyDigits != "0" && onlyDigits.startsWith("0")) {
-    onlyDigits.trimStart('0').ifEmpty { "0" }
-  } else {
-    onlyDigits
+  // Find the index of the first digit that is not 0 or the first occurrence of '.'
+  val firstNonZeroDigitOrDotIndex =
+      filteredInput.indexOfFirst { it != '0' || it == '.' }.takeIf { it != -1 } ?: return "0"
+
+  // Extract the substring from the first non-zero digit or dot to the end
+  val result = filteredInput.substring(firstNonZeroDigitOrDotIndex)
+
+  // Handle cases where the result is only "." or starts with "."
+  return when {
+    result.isEmpty() || result == "." -> "0"
+    result.startsWith('.') -> "0$result" // Prefix a leading zero if it starts with a dot
+    else -> result
   }
 }
 

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -1,0 +1,77 @@
+package com.github.se.polyfit.viewmodel.meal
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.github.se.polyfit.data.remote.firebase.MealFirebaseRepository
+import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+
+class MealViewModel(userID: String, firebaseID: String = "", meal: Meal? = null) : ViewModel() {
+  // after friday use hilt dependency injection to make code cleaner, for now i guess this is ok
+  private val mealRepo: MealFirebaseRepository = MealFirebaseRepository(userID)
+  private val _meal: MutableLiveData<Meal> = MutableLiveData(null)
+  val meal: LiveData<Meal> = _meal
+
+  init {
+    if (firebaseID.isNotEmpty()) {
+      mealRepo.getMeal(firebaseID).addOnCompleteListener {
+        if (it.isSuccessful) {
+          _meal.value = it.result
+        }
+      }
+    } else if (meal != null) {
+      _meal.value = meal.copy()
+    } else {
+      _meal.value =
+          Meal(
+              MealOccasion.NONE,
+              "Temporary Meal Name",
+              0,
+              20.0,
+              NutritionalInformation(mutableListOf()),
+              mutableListOf(),
+              firebaseID)
+    }
+  }
+
+  fun setMeal() {
+    if (_meal.value == null) {
+      throw IllegalStateException("Meal is null")
+    }
+
+    if (!_meal.value!!.isComplete()) {
+      throw Exception("Meal is incomplete")
+    }
+
+    mealRepo.storeMeal(_meal.value!!)
+  }
+
+  fun addIngredient(ingredient: Ingredient) {
+    val currentMeal = _meal.value
+    if (currentMeal != null) {
+      // TODO: Ideally use the Meal.addIngredient method but its not working rn...
+      val updatedMeal =
+          currentMeal.copy(
+              ingredients = currentMeal.ingredients.toMutableList().apply { add(ingredient) },
+              nutritionalInformation =
+                  currentMeal.nutritionalInformation.plus(ingredient.nutritionalInformation))
+      _meal.value = updatedMeal // Emit the new instance as the current state
+    }
+  }
+
+  fun removeIngredient(ingredient: Ingredient) {
+    val currentMeal = _meal.value
+    if (currentMeal != null) {
+      // TODO: Use a method of Meal somehow
+      val updatedMeal =
+          currentMeal.copy(
+              ingredients = currentMeal.ingredients.toMutableList().apply { remove(ingredient) },
+              nutritionalInformation =
+                  currentMeal.nutritionalInformation.minus(ingredient.nutritionalInformation))
+      _meal.value = updatedMeal
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -6,8 +6,6 @@ import androidx.lifecycle.ViewModel
 import com.github.se.polyfit.data.remote.firebase.MealFirebaseRepository
 import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
-import com.github.se.polyfit.model.meal.MealOccasion
-import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 
 class MealViewModel(
     private val userId: String,
@@ -29,15 +27,7 @@ class MealViewModel(
     } else if (initialMeal != null) {
       _meal.value = initialMeal.copy()
     } else {
-      _meal.value =
-          Meal(
-              MealOccasion.NONE,
-              "",
-              0,
-              20.0,
-              NutritionalInformation(mutableListOf()),
-              mutableListOf(),
-              firebaseID)
+      _meal.value = Meal.default()
     }
   }
 
@@ -50,7 +40,11 @@ class MealViewModel(
       throw Exception("Meal is incomplete")
     }
 
-    mealRepo.storeMeal(_meal.value!!)
+    try {
+      mealRepo.storeMeal(_meal.value!!)
+    } catch (e: Exception) {
+      throw e
+    }
   }
 
   fun addIngredient(ingredient: Ingredient) {

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -9,9 +9,13 @@ import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
 import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 
-class MealViewModel(userID: String, firebaseID: String = "", meal: Meal? = null) : ViewModel() {
+class MealViewModel(
+    private val userId: String,
+    firebaseID: String = "",
+    initialMeal: Meal? = null,
+    private val mealRepo: MealFirebaseRepository = MealFirebaseRepository(userId)
+) : ViewModel() {
   // after friday use hilt dependency injection to make code cleaner, for now i guess this is ok
-  private val mealRepo: MealFirebaseRepository = MealFirebaseRepository(userID)
   private val _meal: MutableLiveData<Meal> = MutableLiveData(null)
   val meal: LiveData<Meal> = _meal
 
@@ -22,13 +26,13 @@ class MealViewModel(userID: String, firebaseID: String = "", meal: Meal? = null)
           _meal.value = it.result
         }
       }
-    } else if (meal != null) {
-      _meal.value = meal.copy()
+    } else if (initialMeal != null) {
+      _meal.value = initialMeal.copy()
     } else {
       _meal.value =
           Meal(
               MealOccasion.NONE,
-              "Temporary Meal Name",
+              "",
               0,
               20.0,
               NutritionalInformation(mutableListOf()),

--- a/app/src/test/java/com/github/se/polyfit/model/meal/MealOccasionTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/meal/MealOccasionTest.kt
@@ -11,6 +11,7 @@ class MealOccasionTest {
     assertEquals(MealOccasion.LUNCH, MealOccasion.fromString("LUNCH"))
     assertEquals(MealOccasion.DINNER, MealOccasion.fromString("DINNER"))
     assertEquals(MealOccasion.SNACK, MealOccasion.fromString("SNACK"))
+    assertEquals(MealOccasion.NONE, MealOccasion.fromString("NONE"))
   }
 
   @Test

--- a/app/src/test/java/com/github/se/polyfit/model/meal/MealOccasionTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/meal/MealOccasionTest.kt
@@ -11,7 +11,7 @@ class MealOccasionTest {
     assertEquals(MealOccasion.LUNCH, MealOccasion.fromString("LUNCH"))
     assertEquals(MealOccasion.DINNER, MealOccasion.fromString("DINNER"))
     assertEquals(MealOccasion.SNACK, MealOccasion.fromString("SNACK"))
-    assertEquals(MealOccasion.NONE, MealOccasion.fromString("NONE"))
+    assertEquals(MealOccasion.OTHER, MealOccasion.fromString("OTHER"))
   }
 
   @Test

--- a/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
@@ -72,10 +72,10 @@ class MealTest {
             "nutritionalInformation" to NutritionalInformation(mutableListOf()).serialize())
     val meal = Meal.deserialize(data)
     assertNotNull(meal)
-    assertEquals(1.toLong(), meal?.mealID)
-    assertEquals(MealOccasion.DINNER, meal?.occasion)
-    assertEquals("eggs", meal?.name)
-    assertEquals(102.2, meal?.mealTemp)
+    assertEquals(1.toLong(), meal.mealID)
+    assertEquals(MealOccasion.DINNER, meal.occasion)
+    assertEquals("eggs", meal.name)
+    assertEquals(102.2, meal.mealTemp, 0.001)
   }
 
   @Test
@@ -91,5 +91,85 @@ class MealTest {
     val meal = Meal.deserialize(data)
     val deserialized = Meal.deserialize(data)
     assertEquals(meal, deserialized)
+  }
+
+  @Test
+  fun `meal without name is incomplete`() {
+    val meal =
+        Meal(
+            MealOccasion.DINNER,
+            name = "",
+            mealID = 1,
+            mealTemp = 102.2,
+            nutritionalInformation =
+                NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G))),
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        "milk",
+                        1,
+                        102.0,
+                        MeasurementUnit.MG,
+                        NutritionalInformation(mutableListOf()))))
+
+    assertEquals(false, meal.isComplete())
+  }
+
+  @Test
+  fun `meal without ingredients is incomplete`() {
+    val meal =
+        Meal(
+            MealOccasion.DINNER,
+            name = "eggs",
+            mealID = 1,
+            mealTemp = 102.2,
+            nutritionalInformation =
+                NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G))),
+            ingredients = mutableListOf())
+
+    assertEquals(false, meal.isComplete())
+  }
+
+  @Test
+  fun `meal without nutritional information is incomplete`() {
+    val meal =
+        Meal(
+            MealOccasion.DINNER,
+            name = "eggs",
+            mealID = 1,
+            mealTemp = 102.2,
+            nutritionalInformation = NutritionalInformation(mutableListOf()),
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        "milk",
+                        1,
+                        102.0,
+                        MeasurementUnit.MG,
+                        NutritionalInformation(mutableListOf()))))
+
+    assertEquals(false, meal.isComplete())
+  }
+
+  @Test
+  fun `meal with all mandatory fields is complete`() {
+    val meal =
+        Meal(
+            MealOccasion.DINNER,
+            name = "eggs",
+            mealID = 1,
+            mealTemp = 102.2,
+            nutritionalInformation =
+                NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G))),
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        "milk",
+                        1,
+                        102.0,
+                        MeasurementUnit.MG,
+                        NutritionalInformation(mutableListOf()))))
+
+    assertEquals(true, meal.isComplete())
   }
 }

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutrientTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutrientTest.kt
@@ -95,4 +95,20 @@ class NutrientTest {
     val nutrient = Nutrient("vitaminb4", 100.0, MeasurementUnit.IU)
     Assert.assertEquals("Vitamin B4", nutrient.getFormattedName())
   }
+
+  @Test
+  fun `multiply nutrient by a scalar`() {
+    val nutrient = Nutrient("fats", 100.0, MeasurementUnit.G)
+    val result = nutrient * 2.0
+    Assert.assertEquals(200.0, result.amount, 0.001)
+    Assert.assertEquals(MeasurementUnit.G, result.unit)
+  }
+
+  @Test
+  fun `multiply nutrient by negative scalar`() {
+    val nutrient = Nutrient("vitaminb4", 5.2, MeasurementUnit.IU)
+    val result = nutrient * -2.0
+    Assert.assertEquals(-10.4, result.amount, 0.001)
+    Assert.assertEquals(MeasurementUnit.IU, result.unit)
+  }
 }

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
@@ -109,7 +109,7 @@ class NutritionalInformationTest {
   }
 
   @Test
-  fun `plus operator  should add nutritional information correctly`() {
+  fun `plus operator should add nutritional information correctly`() {
     val nutritionalInformation1 =
         NutritionalInformation(
             mutableListOf(
@@ -134,6 +134,35 @@ class NutritionalInformationTest {
         result.nutrients.filter { it.nutrientType == "calories" }[0])
     assertEquals(
         Nutrient("fat", 15.0, MeasurementUnit.G),
+        result.nutrients.filter { it.nutrientType == "fat" }[0])
+  }
+
+  @Test
+  fun `minus operator should add nutritional information correctly`() {
+    val nutritionalInformation1 =
+        NutritionalInformation(
+            mutableListOf(
+                Nutrient("totalWeight", 100.0, MeasurementUnit.G),
+                Nutrient("calories", 200.0, MeasurementUnit.CAL),
+                Nutrient("fat", 10.0, MeasurementUnit.G)))
+
+    val nutritionalInformation2 =
+        NutritionalInformation(
+            mutableListOf(
+                Nutrient("totalWeight", 50.0, MeasurementUnit.G),
+                Nutrient("calories", 100.0, MeasurementUnit.CAL),
+                Nutrient("fat", 5.0, MeasurementUnit.G)))
+
+    val result = nutritionalInformation1 - nutritionalInformation2
+
+    assertEquals(
+        Nutrient("totalWeight", 50.0, MeasurementUnit.G),
+        result.nutrients.filter { it.nutrientType == "totalWeight" }[0])
+    assertEquals(
+        Nutrient("calories", 100.0, MeasurementUnit.CAL),
+        result.nutrients.filter { it.nutrientType == "calories" }[0])
+    assertEquals(
+        Nutrient("fat", 5.0, MeasurementUnit.G),
         result.nutrients.filter { it.nutrientType == "fat" }[0])
   }
 

--- a/app/src/test/java/com/github/se/polyfit/ui/utils/StringUtilsTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/ui/utils/StringUtilsTest.kt
@@ -22,7 +22,7 @@ class StringUtilsTest {
   @Test
   fun `removeLeadingZeros and non-digits - only non-digits`() {
     val result = removeLeadingZerosAndNonDigits("abc")
-    assertEquals("", result)
+    assertEquals("0", result)
   }
 
   @Test
@@ -46,13 +46,25 @@ class StringUtilsTest {
   @Test
   fun `removeLeadingZeros and non-digits - empty string`() {
     val result = removeLeadingZerosAndNonDigits("")
-    assertEquals("", result)
+    assertEquals("0", result)
   }
 
   @Test
   fun `removeLeadingZeros and non-digits - zeros and non-digits`() {
     val result = removeLeadingZerosAndNonDigits("00abc")
     assertEquals("0", result)
+  }
+
+  @Test
+  fun `encounter first dot`() {
+    val result = removeLeadingZerosAndNonDigits("00.1234")
+    assertEquals("0.1234", result)
+  }
+
+  @Test
+  fun `encounter many dots`() {
+    val result = removeLeadingZerosAndNonDigits("00.12.34")
+    assertEquals("0.1234", result)
   }
 
   @Test

--- a/app/src/test/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
@@ -39,7 +39,7 @@ class MealViewModelTest {
     val meal = mealViewModel.meal.value!!
 
     assertEquals(meal.name, "")
-    assertEquals(meal.occasion, MealOccasion.NONE)
+    assertEquals(meal.occasion, MealOccasion.OTHER)
     assert(meal.nutritionalInformation.nutrients.isEmpty())
     assert(meal.ingredients.isEmpty())
     assertEquals(meal.firebaseId, "")

--- a/app/src/test/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/viewmodel/meal/MealViewModelTest.kt
@@ -1,0 +1,140 @@
+package com.github.se.polyfit.viewmodel.meal
+
+import com.github.se.polyfit.data.remote.firebase.MealFirebaseRepository
+import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
+import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MealViewModelTest {
+  private val userID = "testUserID"
+  private val firebaseID = "testFirebaseID"
+
+  private lateinit var mealViewModel: MealViewModel
+  private val mealFirebaseRepository: MealFirebaseRepository = mockk()
+
+  @Before
+  fun setup() {
+    every { mealFirebaseRepository.getMeal(firebaseID) } returns mockk()
+    every { mealFirebaseRepository.storeMeal(any()) } returns mockk()
+  }
+
+  @Test
+  fun `viewmodel with empty paramters creates default`() {
+    mealViewModel = MealViewModel(userID, mealRepo = mealFirebaseRepository)
+
+    val meal = mealViewModel.meal.value!!
+
+    assertEquals(meal.name, "")
+    assertEquals(meal.occasion, MealOccasion.NONE)
+    assert(meal.nutritionalInformation.nutrients.isEmpty())
+    assert(meal.ingredients.isEmpty())
+    assertEquals(meal.firebaseId, "")
+  }
+
+  @Test
+  fun `viewmodel with initial meal sets meal`() {
+    val initialMeal =
+        Meal(
+            MealOccasion.BREAKFAST,
+            "testMeal",
+            1,
+            20.0,
+            NutritionalInformation(mutableListOf()),
+            mutableListOf(),
+            "testID")
+
+    mealViewModel =
+        MealViewModel(userID, initialMeal = initialMeal, mealRepo = mealFirebaseRepository)
+    val meal = mealViewModel.meal.value!!
+
+    assertEquals(initialMeal, meal)
+  }
+
+  // TODO: Setup the mock data for the getMeal method
+  @Ignore
+  @Test
+  fun `viewmodel with firebaseID gets meal from repo`() {
+    mealViewModel = MealViewModel(userID, firebaseID, mealRepo = mealFirebaseRepository)
+
+    // verify that getMeal was called with the firebaseID
+    verify { mealFirebaseRepository.getMeal(firebaseID) }
+  }
+
+  @Test
+  fun `addIngredient adds ingredient to meal`() {
+    val ingredient =
+        Ingredient(
+            "testIngredient", 1, 1.0, MeasurementUnit.G, NutritionalInformation(mutableListOf()))
+    mealViewModel = MealViewModel(userID, mealRepo = mealFirebaseRepository)
+
+    mealViewModel.addIngredient(ingredient)
+
+    val meal = mealViewModel.meal.value!!
+    assert(meal.ingredients.contains(ingredient))
+  }
+
+  @Test
+  fun `removeIngredient removes ingredient from meal`() {
+    val ingredient =
+        Ingredient(
+            "testIngredient", 1, 1.0, MeasurementUnit.G, NutritionalInformation(mutableListOf()))
+    val initialMeal =
+        Meal(
+            MealOccasion.BREAKFAST,
+            "testMeal",
+            1,
+            20.0,
+            NutritionalInformation(mutableListOf()),
+            mutableListOf(ingredient),
+            "testID")
+    mealViewModel =
+        MealViewModel(userID, initialMeal = initialMeal, mealRepo = mealFirebaseRepository)
+
+    mealViewModel.removeIngredient(ingredient)
+
+    val meal = mealViewModel.meal.value!!
+    assert(meal.ingredients.isEmpty())
+  }
+
+  @Test
+  fun `setMeal throws exception if meal is not complete`() {
+    mealViewModel = MealViewModel(userID, mealRepo = mealFirebaseRepository)
+
+    assertFailsWith<Exception> { mealViewModel.setMeal() }
+  }
+
+  @Test
+  fun `setMeal calls storeMeal on repo`() {
+    val ingredient =
+        Ingredient(
+            "testIngredient", 1, 1.0, MeasurementUnit.G, NutritionalInformation(mutableListOf()))
+    val meal =
+        Meal(
+            MealOccasion.BREAKFAST,
+            "testMeal",
+            1,
+            20.0,
+            NutritionalInformation(mutableListOf(Nutrient("testNutrient", 1.0, MeasurementUnit.G))),
+            mutableListOf(ingredient),
+            "testID")
+    mealViewModel = MealViewModel(userID, initialMeal = meal, mealRepo = mealFirebaseRepository)
+
+    mealViewModel.setMeal()
+
+    verify { mealFirebaseRepository.storeMeal(meal) }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,5 +13,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Polyfit"
+rootProject.name = "polyfit"
 include(":app") 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,5 +13,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "polyfit"
+rootProject.name = "Polyfit"
 include(":app") 


### PR DESCRIPTION
Built a MealViewModel that controls the flow of building one Meal, and updated the UI to integrate. Sorry for the large PR. It includes my work and April's.

Meal View Model Features:
- [x] setMeal --> Upload the finalized `Meal` to DB
- [x] addIngredient --> Add an `Ingredient` to the `Meal`
- [x] removeIngredient --> Remove an `Ingredient` from the `Meal`
- [x] If given a `firebaseID`, it will fetch that and use that as the meal value
- [x] If instead given a `Meal`, will use that as the value
- [x] If given neither, then sets a default meal with some empty values

UI Integrations
- [x] Allow Ingredient page to accept a `MealViewModel`, and use it to display ingredients
- [x] Allow Nutrition page to accept `MealViewModel` and use it to display nutrition & title
- [x] Add Ingredient Popup should add an ingredient to the meal
- [x] Once done is clicked, it should store a meal in the DB

Other things included:
- Helper functions on various data models
- String util helpers

Also Includes: https://github.com/swent-group10/polyfit/pull/85