### PR TITLE
Issue with Spoonacular API keys when compilling apk and ci pipeline

### DIFF
--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ github.run_id }}-${{ github.event.timestamp }}
+          tag_name: ${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ github.run_id }}-${{ format(github.event.timestamp, 'YYYYMMDDHHmmss') }}
           release_name: Release ${{ github.ref_name }} Version ${{ github.run_number }} on ${{ github.event.commits[0].timestamp }}
           draft: false
           prerelease: false

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'release/**'
       - 'main'
-      - 'bugfix/**'
 
 jobs:
   build:
@@ -48,7 +47,7 @@ jobs:
           draft: false
           prerelease: false
           body: "Changes in this release:\n${{ join('\n', github.event.commits.*.message) }}"
-        if: startsWith(github.ref, 'refs/heads/bugfix/')
+        if: startsWith(github.ref, 'refs/heads/release/')
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
@@ -58,4 +57,4 @@ jobs:
           asset_path: app/build/outputs/apk/release/app-release-unsigned.apk
           asset_name: app-release.apk
           asset_content_type: application/vnd.android.package-archive
-        if: startsWith(github.ref, 'refs/heads/bugfix/')
+        if: startsWith(github.ref, 'refs/heads/release/')

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -6,6 +6,7 @@ on:
       - release/*
       - main
       - Main
+      - bugfix/*
 
 jobs:
   build:
@@ -20,6 +21,11 @@ jobs:
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
+      - name: Set up API keys
+        run: |
+          echo "sdk.dir=${ANDROID_HOME}" > local.properties
+          echo "X_RapidAPI_Key=${{ secrets.X_RapidAPI_Key }}" >> local.properties
+          echo "X_RapidAPI_Host=${{ secrets.X_RapidAPI_Host }}" >> local.properties
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -48,7 +48,7 @@ jobs:
           tag_name: ${{ github.ref_name }}-${{ github.sha }}-v${{ github.run_number }}-${{ github.run_id }}
           release_name: Release ${{ github.ref_name }} Version ${{ github.run_number }} on ${{ github.event.commits[0].timestamp }}
           draft: false # not shown to users and it does not trigger any notifications or webhooks.
-          prerelease: true # indicates that the release is a pre-release.
+          prerelease: false # indicates that the release is a pre-release.
           body: |
             Changes in this release:
             ${{ join('\n', github.event.commits.*.message) }}

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -52,7 +52,7 @@ jobs:
           body: |
             Changes in this release:
             ${{ join('\n', github.event.commits.*.message) }}
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: startsWith(github.ref, 'refs/heads/bugfix/')
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
@@ -63,4 +63,4 @@ jobs:
           asset_path: app/build/outputs/apk/release/app-release-unsigned.apk
           asset_name: app-release.apk
           asset_content_type: application/vnd.android.package-archive
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: startsWith(github.ref, 'refs/heads/bugfix/')

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ github.run_id }}-${{ format(github.event.timestamp, 'YYYYMMDDHHmmss') }}
+          tag_name: ${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ github.run_id }}-${{ steps.date.outputs.date }}
           release_name: Release ${{ github.ref_name }} Version ${{ github.run_number }} on ${{ github.event.commits[0].timestamp }}
           draft: false
           prerelease: false

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -43,8 +43,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ github.run_id }}-${{ steps.date.outputs.date }}
-          release_name: Release ${{ github.ref_name }} Version ${{ github.run_number }} on ${{ github.event.commits[0].timestamp }}
+          tag_name: ${{ github.sha }}-${{ github.run_number }}
+          release_name: Release ${{ github.ref_name }} Version ${{ github.run_number }}
           draft: false
           prerelease: false
           body: "Changes in this release:\n${{ join('\n', github.event.commits.*.message) }}"

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -3,10 +3,9 @@ name: Build Android APK
 on:
   push:
     branches:
-      - release/*
-      - main
-      - Main
-      - bugfix/*
+      - 'release/**'
+      - 'main'
+      - 'bugfix/**'
 
 jobs:
   build:
@@ -20,7 +19,7 @@ jobs:
       - name: Create Google Services JSON File
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-        run: echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
+        run: echo "$GOOGLE_SERVICES_JSON" | base64 --decode > ./app/google-services.json
       - name: Set up API keys
         run: |
           echo "sdk.dir=${ANDROID_HOME}" > local.properties
@@ -33,7 +32,6 @@ jobs:
           java-version: "17"
       - name: Build APK
         run: ./gradlew assembleRelease
-
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
@@ -45,15 +43,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-${{ github.sha }}-v${{ github.run_number }}-${{ github.run_id }}
+          tag_name: ${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ github.run_id }}-${{ github.event.timestamp }}
           release_name: Release ${{ github.ref_name }} Version ${{ github.run_number }} on ${{ github.event.commits[0].timestamp }}
-          draft: false # not shown to users and it does not trigger any notifications or webhooks.
-          prerelease: false # indicates that the release is a pre-release.
-          body: |
-            Changes in this release:
-            ${{ join('\n', github.event.commits.*.message) }}
+          draft: false
+          prerelease: false
+          body: "Changes in this release:\n${{ join('\n', github.event.commits.*.message) }}"
         if: startsWith(github.ref, 'refs/heads/bugfix/')
-
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
 
+        # Set up API keys
+      - name: Set up API keys
+        run: |
+          echo "sdk.dir=${ANDROID_HOME}" > local.properties
+          echo "X_RapidAPI_Key=${{ secrets.X_RapidAPI_Key }}" >> local.properties
+          echo "X_RapidAPI_Host=${{ secrets.X_RapidAPI_Host }}" >> local.properties
+
       # This step runs gradle commands to build the application
       - name: Assemble
         id: build


### PR DESCRIPTION
## PR Description 

- Due to a change in the project, when compiling, Gradle checks a local file for API keys. However, this was not taken into account in the previous iteration of the APK (#65) and the CI. The PR addresses this by creating a new local file during compilation and adds the API keys.