### PR TITLE
FIX: Ensuring no negative nutrients in NutritionalInfo

### DIFF
--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
@@ -40,7 +40,8 @@ class NutritionalInformation {
 
   /**
    * Update the nutritional information with new values. If the nutrient type already exists, the
-   * amount is updated. If the nutrient type does not exist, a new nutrient is added.
+   * amount is updated. If the nutrient type does not exist, a new nutrient is added. We make sure
+   * all nutrients have positive amounts.
    *
    * @param newValues the new values to update the nutritional information with
    */
@@ -53,10 +54,12 @@ class NutritionalInformation {
             val index = nutrients.indexOfFirst { it.nutrientType == newValues.nutrientType }
 
             nutrients[index] = (nutrients[index] + newValues)!!
-          } else {
+          } else if (newValues.amount >= 0.0) {
             nutrients.add(newValues.deepCopy())
           }
         }
+
+    nutrients.removeIf { it.amount < 0.0 }
   }
 
   fun update(newValues: NutritionalInformation) {
@@ -76,7 +79,6 @@ class NutritionalInformation {
     return newNutritionalInformation
   }
 
-  // TODO: Prevent negative values
   operator fun minus(other: NutritionalInformation): NutritionalInformation {
     val newNutritionalInformation = NutritionalInformation(mutableListOf())
 

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
@@ -59,7 +59,9 @@ class NutritionalInformation {
           }
         }
 
-    nutrients.removeIf { it.amount < 0.0 }
+    val anyRemoved = nutrients.removeIf { it.amount < 0.0 }
+
+    if (anyRemoved) Log.d("NutritionalInformation", "Removed negative nutrient(s)")
   }
 
   fun update(newValues: NutritionalInformation) {

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
@@ -18,6 +18,7 @@ class NutritionalInformationTest {
     mockkStatic(Log::class)
     every { Log.e(any(), any()) } returns 0
     every { Log.e(any(), any(), any()) } returns 0
+    every { Log.d(any(), any()) } returns 0
 
     nutritionalInformation =
         NutritionalInformation(

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
@@ -167,6 +167,24 @@ class NutritionalInformationTest {
   }
 
   @Test
+  fun `minus function should remove a Nutrient if it goes negative`() {
+    val nutritionalInformation1 =
+        NutritionalInformation(
+            mutableListOf(
+                Nutrient("totalWeight", 100.0, MeasurementUnit.G),
+                Nutrient("calories", 200.0, MeasurementUnit.CAL)))
+    val nutritionalInformation2 =
+        NutritionalInformation(
+            mutableListOf(
+                Nutrient("totalWeight", 50.0, MeasurementUnit.G),
+                Nutrient("calories", 200.1, MeasurementUnit.CAL)))
+
+    val result = nutritionalInformation1 - nutritionalInformation2
+    assert(result.nutrients.size == 1)
+    assert(result.nutrients[0].nutrientType == "totalWeight")
+  }
+
+  @Test
   fun `update function should correctly update nutritional information`() {
     val nutritionalInformation1 =
         NutritionalInformation(
@@ -182,6 +200,28 @@ class NutritionalInformationTest {
     assertEquals(
         Nutrient("totalWeight", 150.0, MeasurementUnit.G),
         nutritionalInformation1.nutrients.filter { it.nutrientType == "totalWeight" }[0])
+  }
+
+  @Test
+  fun `update shouldn't add a nutrient if the amount is less than 0`() {
+    val nutritionalInformation1 = NutritionalInformation(mutableListOf())
+    val nutritionalInformation2 =
+        NutritionalInformation(mutableListOf(Nutrient("totalWeight", -10.0, MeasurementUnit.G)))
+
+    nutritionalInformation1.update(nutritionalInformation2)
+    assert(nutritionalInformation1.nutrients.isEmpty())
+  }
+
+  @Test
+  fun `update should subtract from existing nutrient if amount is less than 0`() {
+    val nutritionalInformation1 =
+        NutritionalInformation(mutableListOf(Nutrient("totalWeight", 10.0, MeasurementUnit.G)))
+    val nutritionalInformation2 =
+        NutritionalInformation(mutableListOf(Nutrient("totalWeight", -5.0, MeasurementUnit.G)))
+
+    nutritionalInformation1.update(nutritionalInformation2)
+    assert(nutritionalInformation1.nutrients.size == 1)
+    assert(nutritionalInformation1.nutrients[0].amount == 5.0)
   }
 
   @Test


### PR DESCRIPTION
https://github.com/swent-group10/polyfit/issues/95

Quick PR to prevent Nutritional Information from having negative values. I decided it would be ok to leave the `Nutrient` if it is zero because it is helpful to see that there is no amount of a nutrient visually.