### PR TITLE
Store date of meal creation in DB

### DIFF
--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -3,6 +3,7 @@ package com.github.se.polyfit.model.meal
 import android.util.Log
 import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import java.time.LocalDate
 
 // modeled after the log meal api
 data class Meal(
@@ -14,7 +15,8 @@ data class Meal(
     val mealTemp: Double = 20.0,
     val nutritionalInformation: NutritionalInformation,
     val ingredients: MutableList<Ingredient> = mutableListOf(),
-    var firebaseId: String = ""
+    var firebaseId: String = "",
+    val createdAt: LocalDate = LocalDate.now(),
 ) {
   init {
     require(mealID >= 0)
@@ -33,6 +35,7 @@ data class Meal(
     if (nutritionalInformation != other.nutritionalInformation) return false
     if (ingredients != other.ingredients) return false
     if (firebaseId != other.firebaseId) return false
+    if (createdAt != other.createdAt) return false
 
     return true
   }
@@ -45,6 +48,7 @@ data class Meal(
     result = 31 * result + nutritionalInformation.hashCode()
     result = 31 * result + ingredients.hashCode()
     result = 31 * result + firebaseId.hashCode()
+    result = 31 * result + createdAt.hashCode()
 
     return result
   }
@@ -74,7 +78,6 @@ data class Meal(
   }
 
   private fun updateMeal() {
-
     var newNutritionalInformation = NutritionalInformation(mutableListOf())
 
     for (ingredient in ingredients) {
@@ -98,6 +101,7 @@ data class Meal(
         this["nutritionalInformation"] =
             NutritionalInformation.serialize(data.nutritionalInformation)
         this["ingredients"] = data.ingredients.map { Ingredient.serialize(it) }
+        this["createdAt"] = data.createdAt.toString()
       }
     }
 
@@ -113,8 +117,16 @@ data class Meal(
         val nutritionalInformationData =
             NutritionalInformation.deserialize(
                 data["nutritionalInformation"] as List<Map<String, Any>>)
+        val createdAt = LocalDate.parse(data["createdAt"] as String)
 
-        val newMeal = Meal(occasion, name, mealID, mealTemp, nutritionalInformationData)
+        val newMeal =
+            Meal(
+                occasion = occasion,
+                name = name,
+                mealID = mealID,
+                mealTemp = mealTemp,
+                nutritionalInformation = nutritionalInformationData,
+                createdAt = createdAt)
 
         val ingredientsData = data["ingredients"] as? List<Map<String, Any>>
         if (ingredientsData != null) {
@@ -137,7 +149,8 @@ data class Meal(
           20.0,
           NutritionalInformation(mutableListOf()),
           mutableListOf(),
-          "")
+          "",
+          LocalDate.now())
     }
   }
 }

--- a/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
@@ -7,6 +7,7 @@ import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import io.mockk.every
 import io.mockk.mockkStatic
+import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import org.junit.Assert.assertEquals
@@ -40,12 +41,18 @@ class MealTest {
   fun `Meal serialize should serialize meal correctly`() {
     val meal =
         Meal(
-            MealOccasion.DINNER, "eggs", 1.toLong(), 102.2, NutritionalInformation(mutableListOf()))
+            MealOccasion.DINNER,
+            "eggs",
+            1.toLong(),
+            102.2,
+            NutritionalInformation(mutableListOf()),
+            createdAt = LocalDate.parse("2021-01-01"))
     val serializedMeal = Meal.serialize(meal)
     assertEquals(1.toLong(), serializedMeal["mealID"])
     assertEquals(MealOccasion.DINNER.name, serializedMeal["occasion"])
     assertEquals("eggs", serializedMeal["name"])
     assertEquals(102.2, serializedMeal["mealTemp"])
+    assertEquals("2021-01-01", serializedMeal["createdAt"])
   }
 
   @Test
@@ -56,7 +63,8 @@ class MealTest {
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to "wrongValue",
-            "nutritionalInformation" to listOf<Map<String, Any>>())
+            "nutritionalInformation" to listOf<Map<String, Any>>(),
+            "createdAt" to "notARealDate")
     // Make sure that an exception is thrown
     assertFailsWith<Exception> { Meal.deserialize(data) }
   }
@@ -69,13 +77,15 @@ class MealTest {
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to 102.2,
-            "nutritionalInformation" to NutritionalInformation(mutableListOf()).serialize())
+            "nutritionalInformation" to NutritionalInformation(mutableListOf()).serialize(),
+            "createdAt" to "2021-01-01")
     val meal = Meal.deserialize(data)
     assertNotNull(meal)
     assertEquals(1.toLong(), meal.mealID)
     assertEquals(MealOccasion.DINNER, meal.occasion)
     assertEquals("eggs", meal.name)
     assertEquals(102.2, meal.mealTemp, 0.001)
+    assertEquals(LocalDate.parse("2021-01-01"), meal.createdAt)
   }
 
   @Test
@@ -86,7 +96,8 @@ class MealTest {
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to 102.2,
-            "nutritionalInformation" to listOf<Map<String, Any>>())
+            "nutritionalInformation" to listOf<Map<String, Any>>(),
+            "createdAt" to "2021-01-01")
 
     val meal = Meal.deserialize(data)
     val deserialized = Meal.deserialize(data)


### PR DESCRIPTION
To show meals of any given day in the overview screen, add a `createdAt` field to our `Meal` so we know which day it belongs.

Ticket: https://github.com/swent-group10/polyfit/issues/99

Confirmation that it uploaded to Firebase:
<img width="480" alt="Screenshot 2024-04-15 at 1 09 22 PM" src="https://github.com/swent-group10/polyfit/assets/68757340/1a14a1c3-14f4-4ea8-b5ba-78ec6f5cb9be">
