### PR TITLE
Create Meal without a Photo

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/OverviewScreenTest.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.polyfit.ui.components.GenericScreen
+import com.github.se.polyfit.ui.flow.AddMealFlow
 import com.github.se.polyfit.ui.navigation.Route
 import com.github.se.polyfit.ui.utils.OverviewTags
 import com.kaspersky.components.composesupport.config.withComposeSupport
@@ -48,6 +49,10 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
           GenericScreen(
               navController = navController,
               content = { paddingValues -> OverviewScreen(paddingValues, navController, mockk()) })
+        }
+
+        composable(Route.AddMeal) {
+          AddMealFlow(goBack = {}, navigateToHome = {}, userID = "Test", mockk(relaxed = true))
         }
       }
     }
@@ -199,6 +204,25 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
         assertExists()
         assertIsDisplayed()
         assertHasClickAction()
+      }
+    }
+  }
+
+  @Test
+  fun editButtonClicked() {
+    ComposeScreen.onComposeScreen<CalorieCard>(composeTestRule) {
+      composeTestRule
+          .onNodeWithTag(OverviewTags.overviewManualBtn)
+          .onChild()
+          .assertExists()
+          .assertIsDisplayed()
+          .assertHasClickAction()
+          .performClick()
+    }
+    ComposeScreen.onComposeScreen<IngredientsTopBar>(composeTestRule) {
+      ingredientTitle {
+        assertExists()
+        assertIsDisplayed()
       }
     }
   }

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/IngredientScreen.kt
@@ -41,8 +41,13 @@ fun IngredientScreen(
 
   val showAddIngredDialog = remember { mutableStateOf(false) }
 
+  fun goBackAndReset() {
+    navigateBack()
+    mealViewModel.reset()
+  }
+
   Scaffold(
-      topBar = { TopBar(navigateBack) },
+      topBar = { TopBar(::goBackAndReset) },
       bottomBar = {
         BottomBar(
             onClickAddIngred = { showAddIngredDialog.value = true },

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/OverviewScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/OverviewScreen.kt
@@ -59,6 +59,7 @@ import com.github.se.polyfit.ui.components.GradientBox
 import com.github.se.polyfit.ui.components.button.GradientButton
 import com.github.se.polyfit.ui.components.dialog.PictureDialog
 import com.github.se.polyfit.ui.components.showToastMessage
+import com.github.se.polyfit.ui.navigation.Navigation
 import com.github.se.polyfit.ui.navigation.Route
 import com.github.se.polyfit.ui.utils.OverviewTags
 import com.github.se.polyfit.viewmodel.meal.MealViewModel
@@ -70,8 +71,8 @@ data class Meal(val name: String, val calories: Int)
 fun MealTrackerCard(
     caloriesGoal: Int,
     meals: List<Pair<MealOccasion, Double>>,
-    onPhoto: () -> Unit,
-    Button2: @Composable () -> Unit = {},
+    onCreateMealFromPhoto: () -> Unit,
+    onCreateMealWithoutPhoto: () -> Unit,
     Button3: @Composable () -> Unit = {}
 ) {
   val context = LocalContext.current
@@ -130,7 +131,7 @@ fun MealTrackerCard(
           modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
           horizontalArrangement = Arrangement.SpaceAround) {
             GradientButton(
-                onClick = onPhoto,
+                onClick = onCreateMealFromPhoto,
                 modifier = Modifier.testTag(OverviewTags.overviewPictureBtn),
                 active = true,
                 icon = {
@@ -140,7 +141,7 @@ fun MealTrackerCard(
                       tint = MaterialTheme.colorScheme.primary)
                 })
             GradientButton(
-                onClick = { Button2 },
+                onClick = onCreateMealWithoutPhoto,
                 modifier = Modifier.testTag(OverviewTags.overviewManualBtn),
                 active = true,
                 icon = {
@@ -196,6 +197,7 @@ fun OverviewScreen(
 ) {
 
   val context = LocalContext.current
+  val navigation = Navigation(navController)
 
   // State to hold the URI, the image and the bitmap
   var imageUri by remember { mutableStateOf<Uri?>(null) }
@@ -285,11 +287,11 @@ fun OverviewScreen(
                         Pair(MealOccasion.BREAKFAST, 300.0),
                         Pair(MealOccasion.LUNCH, 456.0),
                         Pair(MealOccasion.DINNER, 0.0)),
-                onPhoto = {
+                onCreateMealFromPhoto = {
                   showPictureDialog = true
                   Log.d("OverviewScreen", "Photo button clicked")
                 },
-                Button2 = { showToastMessage(context) },
+                onCreateMealWithoutPhoto = navigation::navigateToAddMeal,
                 Button3 = { showToastMessage(context) })
           }
           item {
@@ -308,9 +310,6 @@ fun OverviewScreen(
                                     MaterialTheme.colorScheme.inversePrimary,
                                     MaterialTheme.colorScheme.primary))),
                 colors = CardDefaults.cardColors(Color.Transparent)) {
-
-                  //
-
                   imageBitmap?.let {
                     Image(
                         bitmap = it.asImageBitmap(),

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -96,4 +96,10 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
   fun removeTag(tag: MealTag) {
     _meal.value!!.tags.remove(tag)
   }
+
+  // TODO: This can be removed once we are properly using a new ViewModel for each Meal
+  fun reset() {
+    _meal.value = Meal.default()
+    _isComplete.value = false
+  }
 }


### PR DESCRIPTION
Allow users to create a meal without taking a picture. 

I took the MealViewModel out of the main activity at least and brought it to our main nav graph as it didn't need to be such a high level. Ideally when we can pass around ids rather than mealViewModel, we can get rid of the need to reset it.