### PR TITLE
UI/make a post

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreateAPostScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreateAPostScreen.kt
@@ -1,0 +1,31 @@
+package com.github.se.polyfit.ui.screen
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class CreatePostScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<CreatePostScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("CreatePostScreen") }) {
+
+  val pictureSelector: KNode = child { hasTestTag("PictureSelector") }
+  val postDescription: KNode = child { hasTestTag("PostDescription") }
+  val mealSelector: KNode = child { hasTestTag("MealSelector") }
+}
+
+class CreatePostTopBar(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<CreatePostTopBar>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("TopBar") }) {
+
+  val title: KNode = child { hasTestTag("New Post Title") }
+  val backButton: KNode = child { hasTestTag("BackButton") }
+}
+
+class CreatePostBottomBar(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<CreatePostBottomBar>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("BottomBar") }) {
+
+  private val postBox: KNode = child { hasTestTag("PostBox") }
+  val postButton: KNode = postBox.child { hasTestTag("PostButton") }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreatePostTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreatePostTest.kt
@@ -1,0 +1,127 @@
+package com.github.se.polyfit.ui.screen
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.data.remote.firebase.PostFirebaseRepository
+import com.github.se.polyfit.data.repository.MealRepository
+import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
+import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import com.github.se.polyfit.ui.components.textField.MealInputTextFieldScreen
+import com.github.se.polyfit.viewmodel.post.CreatePostViewModel
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import junit.framework.TestCase
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CreatePostTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  val mockNavForward: () -> Unit = mockk()
+  val mockNavBack: () -> Unit = mockk()
+  private val mockMealRepository = mockk<MealRepository>(relaxed = true)
+  private val mockPostFirebaseRepository = mockk<PostFirebaseRepository>(relaxed = true)
+  private lateinit var viewModel: CreatePostViewModel
+
+  fun setup(meals: List<Meal> = listOf()) {
+    coEvery { mockMealRepository.getAllMeals() } returns meals
+    every { mockNavForward() } just Runs
+    every { mockNavBack() } just Runs
+
+    viewModel = CreatePostViewModel(mockMealRepository, mockPostFirebaseRepository)
+    composeTestRule.setContent { CreatePostScreen(mockNavBack, mockNavForward, viewModel) }
+  }
+
+  fun everythingIsDisplayed() {
+    setup()
+    ComposeScreen.onComposeScreen<CreatePostScreen>(composeTestRule) {
+      pictureSelector {
+        assertExists()
+        assertIsDisplayed()
+      }
+
+      postDescription {
+        assertExists()
+        assertIsDisplayed()
+      }
+
+      mealSelector {
+        assertExists()
+        assertIsDisplayed()
+      }
+    }
+
+    ComposeScreen.onComposeScreen<CreatePostTopBar>(composeTestRule) {
+      title {
+        assertExists()
+        assertIsDisplayed()
+        assertTextEquals("New Post")
+      }
+
+      backButton {
+        assertExists()
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+    }
+
+    ComposeScreen.onComposeScreen<CreatePostBottomBar>(composeTestRule) {
+      postButton {
+        assertExists()
+        assertIsDisplayed()
+        assertIsNotEnabled()
+      }
+    }
+  }
+
+  @Test
+  fun selectingMealEnablesPostButton() {
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    meal.addIngredient(
+        Ingredient(
+            "milk",
+            1,
+            102.0,
+            MeasurementUnit.MG,
+            NutritionalInformation(mutableListOf(Nutrient("calories", 1.0, MeasurementUnit.G)))))
+
+    setup(listOf(meal))
+
+    ComposeScreen.onComposeScreen<CreatePostScreen>(composeTestRule) {
+      mealSelector {
+        assertExists()
+        assertIsDisplayed()
+        performClick()
+      }
+    }
+
+    ComposeScreen.onComposeScreen<MealInputTextFieldScreen>(composeTestRule) {
+      searchMealBar {
+        assertIsDisplayed()
+        performClick()
+      }
+      meal {
+        assertIsDisplayed()
+        performClick()
+      }
+    }
+
+    ComposeScreen.onComposeScreen<CreatePostBottomBar>(composeTestRule) {
+      postButton {
+        assertExists()
+        assertIsDisplayed()
+        assertIsEnabled()
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/post/CreatePostViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/post/CreatePostViewModelTest.kt
@@ -13,6 +13,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import java.time.LocalDate
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -120,7 +121,7 @@ class CreatePostViewModelTest {
   }
 
   @Test
-  fun setPostFailed() = runTest {
+  fun setPostFailed(): Unit = runBlocking {
     coEvery { mockPostFirebaseRepository.storePost(any()) } throws
         Exception("Failed to store post in the database")
     assertFailsWith<Exception> { viewModel.setPost() }

--- a/app/src/main/java/com/github/se/polyfit/data/repository/MealRepository.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/repository/MealRepository.kt
@@ -64,7 +64,7 @@ class MealRepository(
   }
 
   suspend fun getAllMeals(): List<Meal> {
-    return mealDao.getAllMeals()
+    return withContext(this.dispatcher) { mealDao.getAllMeals() }
   }
 
   suspend fun getMealsOnDate(date: LocalDate): List<Meal> {

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/CreatePostScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/CreatePostScreen.kt
@@ -1,0 +1,161 @@
+package com.github.se.polyfit.ui.screen
+
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.github.se.polyfit.R
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.post.Location
+import com.github.se.polyfit.ui.components.button.PrimaryButton
+import com.github.se.polyfit.ui.components.dialog.LocationPermissionDialog
+import com.github.se.polyfit.ui.components.scaffold.CenteredTopBar
+import com.github.se.polyfit.ui.components.selector.MealSelector
+import com.github.se.polyfit.ui.components.selector.PictureSelector
+import com.github.se.polyfit.ui.theme.PrimaryPink
+import com.github.se.polyfit.ui.theme.PrimaryPurple
+import com.github.se.polyfit.ui.theme.SecondaryGrey
+import com.github.se.polyfit.viewmodel.post.CreatePostViewModel
+
+@Composable
+fun CreatePostScreen(
+    navigateBack: () -> Unit = {},
+    navigateForward: () -> Unit = {},
+    postViewModel: CreatePostViewModel = hiltViewModel()
+) {
+  val context = LocalContext.current
+  val meals by postViewModel.meals.collectAsState()
+  var isPermissionDialogDisplay by remember { mutableStateOf(false) }
+  var selectedMeal by remember { mutableStateOf(Meal.default()) }
+  val postComplete by remember(selectedMeal) { derivedStateOf { selectedMeal.isComplete() } }
+
+  fun setPostMeal(meal: Meal) {
+    postViewModel.setPostData(meal = meal)
+  }
+
+  fun onApprove() {
+    isPermissionDialogDisplay = false
+    postViewModel.setPostLocation(Location.default()) // TODO: Include location when ready
+    postViewModel.setPost()
+    navigateForward()
+  }
+
+  Scaffold(
+      topBar = {
+        CenteredTopBar(
+            title = context.getString(R.string.newPostTitle), navigateBack = navigateBack)
+      },
+      bottomBar = {
+        BottomBar(
+            postComplete = postComplete, onButtonPressed = { isPermissionDialogDisplay = true })
+      }) {
+        LazyColumn(modifier = Modifier.padding(it).testTag("CreatePostScreen")) {
+          item { PictureSelector(modifier = Modifier.padding(top = 10.dp)) }
+          item { PostDescription(postViewModel::setPostDescription) }
+          item { HorizontalDivider(thickness = 1.dp, color = Color.LightGray) }
+          item { MealSelector(selectedMeal, { meal -> selectedMeal = meal }, meals, ::setPostMeal) }
+        }
+
+        if (isPermissionDialogDisplay) {
+          LocationPermissionDialog(
+              onApprove = ::onApprove, onDeny = { isPermissionDialogDisplay = false })
+        }
+      }
+}
+
+@Composable
+private fun PostDescription(setPostDescription: (String) -> Unit) {
+  val context = LocalContext.current
+  var descriptionText by remember { mutableStateOf("") }
+
+  TextField(
+      value = descriptionText,
+      onValueChange = {
+        descriptionText = it
+        setPostDescription(it)
+      },
+      modifier = Modifier.fillMaxWidth().heightIn(max = 150.dp).testTag("PostDescription"),
+      textStyle = MaterialTheme.typography.bodyMedium.copy(fontSize = 20.sp),
+      leadingIcon = {
+        Icon(imageVector = Icons.Filled.Edit, contentDescription = "Pen", tint = SecondaryGrey)
+      },
+      placeholder = {
+        Text(
+            text = context.getString(R.string.newPostDescriptionPlaceholder),
+            color = SecondaryGrey,
+            fontSize = 20.sp)
+      },
+      colors =
+          TextFieldDefaults.colors(
+              focusedContainerColor = Color.Transparent,
+              unfocusedContainerColor = Color.Transparent,
+              focusedIndicatorColor = Color.Transparent,
+              unfocusedIndicatorColor = Color.Transparent,
+              cursorColor = PrimaryPurple,
+          ),
+  )
+}
+
+@Composable
+private fun BottomBar(onButtonPressed: () -> Unit, postComplete: Boolean) {
+  val context = LocalContext.current
+  Column(
+      modifier =
+          Modifier.background(MaterialTheme.colorScheme.background)
+              .padding(0.dp, 16.dp, 0.dp, 32.dp)
+              .testTag("BottomBar"),
+  ) {
+    Box(
+        modifier = Modifier.fillMaxWidth().testTag("PostBox"),
+        contentAlignment = Alignment.Center) {
+          PrimaryButton(
+              onClick = {
+                onButtonPressed()
+                Log.v("Finished", "Clicked")
+              },
+              text = context.getString(R.string.postButton),
+              fontSize = 24,
+              modifier = Modifier.width(200.dp).testTag("PostButton"),
+              color = PrimaryPink,
+              isEnabled = postComplete,
+              buttonShape = RoundedCornerShape(12.dp))
+        }
+  }
+}
+
+@Composable
+@Preview
+fun MakePostScreenPreview() {
+  CreatePostScreen()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,7 @@
     <string name="denyRequest">" Cancel "</string>
     <string name="shareRecipePlaceholder">"Share your recipe"</string>
     <string name="enterMealPlaceholder">"Enter a meal…"</string>
+    <string name="newPostTitle">"New Post"</string>
+    <string name="newPostDescriptionPlaceholder">" What's on your mind today?"</string>
+    <string name="postButton">"Post"</string>
 </resources>


### PR DESCRIPTION
UI, UI test for CreatePostScreen. It is fully integrated with backend. 

On this screen, user should be able to draft a post. They can put in optional text descriptions for their post, and are required to select a meal created by themselves to share a post. Before the post is submitted, users are asked for permission to use their location, as the post is visible to those around them.

(Note: see #187 for details on individual components)

<img width="202" alt="image" src="https://github.com/swent-group10/polyfit/assets/72662164/6f496e15-3591-4d3a-9300-c1815bc7be0d">

<img width="201" alt="image" src="https://github.com/swent-group10/polyfit/assets/72662164/522c5704-4012-40e2-a296-4930205a652d">