### PR TITLE
Bug : meal uncomplete not allowing user to proced to next 

### DIFF
--- a/app/src/main/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformation.kt
@@ -1,6 +1,5 @@
 package com.github.se.polyfit.ui.components.nutrition
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -34,15 +33,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.ui.theme.PrimaryPurple
 import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @Composable
 fun NutritionalInformation(mealViewModel: MealViewModel) {
-  val meal by mealViewModel.meal.collectAsState(initial = Meal.default())
-  Log.d("NutritionalInformation", "Meal: $meal")
+  val meal by mealViewModel.meal.collectAsState()
   val nutritionalInformation = meal.nutritionalInformation
   val nutrients = nutritionalInformation.nutrients
   val calories = nutritionalInformation.getNutrient("calories")

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
@@ -40,7 +40,6 @@ fun NutritionScreen(
     navigateForward: () -> Unit
 ) {
   val isComplete by mealViewModel.isComplete.collectAsState()
-  Log.d("NutritionalInformation", "isComplete: $isComplete")
 
   Scaffold(
       topBar = { TopBar(navigateBack = navigateBack) },

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -27,12 +27,7 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
     get() = _isComplete
 
   init {
-    viewModelScope.launch {
-      _meal.collect { meal ->
-        _isComplete.value = meal.isComplete()
-        Log.d("MealViewModel", "Meal is complete: ${_isComplete.value}")
-      }
-    }
+    viewModelScope.launch { _meal.collect { meal -> _isComplete.value = meal.isComplete() } }
   }
 
   fun setMealData(meal: Meal) {
@@ -89,12 +84,7 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
   }
 
   fun removeIngredient(ingredient: Ingredient) {
-    val updatedIngredients =
-        _meal.value.ingredients.toMutableList().apply {
-          remove(ingredient)
-          Log.d("MealViewModel", "Removed ingredient: $ingredient")
-        }
-    Log.d("MealViewModel", "Removed ingredient: $ingredient")
+    val updatedIngredients = _meal.value.ingredients.toMutableList().apply { remove(ingredient) }
 
     _meal.value = _meal.value.copy(ingredients = updatedIngredients)
   }


### PR DESCRIPTION
# Pull Request Overview

This PR addresses a bug that prevented the name of a detected meal from appearing in the `NutritionalInformation.kt` screen. This issue made it impossible for users to proceed to the next screen without manually entering a name that should have been automatically displayed.

## Changes

- **Modify `NutritionalInformation.kt` Class**: The bug was due to incorrect initialization of the `meal` variable.

### Original Code (NutritionalInformation.kt line 42):
```kotlin
val meal by mealViewModel.meal.collectAsState(initial = Meal.default())
``` 
### Updated Code (NutritionalInformation.kt line 42):

```kotlin
  val meal by mealViewModel.meal.collectAsState()
``` 
By removing the default initial value, the meal now properly initializes based on the current state managed by mealViewModel and not the `Meal.default()` value.

# Additional Resource 

https://github.com/swent-group10/polyfit/assets/100274930/ee49e0fc-132e-4e2c-a08b-62047d1120a8


