### PR TITLE
Bugfix: MealViewModel Mistakes

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformationTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
 import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
@@ -30,61 +31,79 @@ class NutritionalInformationTest : TestCase() {
   @get:Rule val composeTestRule = createComposeRule()
 
   private val onlyCalories =
-      NutritionalInformation(
-          mutableListOf(
-              Nutrient("calories", 100.0, MeasurementUnit.CAL),
-          ))
+      Ingredient(
+          name = "Test",
+          id = 0,
+          amount = 1.0,
+          unit = MeasurementUnit.UNIT,
+          nutritionalInformation =
+              NutritionalInformation(
+                  mutableListOf(
+                      Nutrient("calories", 100.0, MeasurementUnit.CAL),
+                  )))
 
   private val noCaloriesInfo =
-      NutritionalInformation(
-          mutableListOf(
-              Nutrient("totalWeight", 100.0, MeasurementUnit.G),
-              Nutrient("fat", 10.0, MeasurementUnit.G),
-              Nutrient("saturatedFat", 3.0, MeasurementUnit.G),
-              Nutrient("carbohydrates", 20.0, MeasurementUnit.G),
-          ))
+      Ingredient(
+          name = "Test",
+          id = 0,
+          amount = 1.0,
+          unit = MeasurementUnit.UNIT,
+          nutritionalInformation =
+              NutritionalInformation(
+                  mutableListOf(
+                      Nutrient("totalWeight", 100.0, MeasurementUnit.G),
+                      Nutrient("fat", 10.0, MeasurementUnit.G),
+                      Nutrient("saturatedFat", 3.0, MeasurementUnit.G),
+                      Nutrient("carbohydrates", 20.0, MeasurementUnit.G),
+                  )))
 
   private val nutritionalInformation =
-      NutritionalInformation(
-          mutableListOf(
-              Nutrient("totalWeight", 100.0, MeasurementUnit.G),
-              Nutrient("calories", 200.0, MeasurementUnit.CAL),
-              Nutrient("fat", 10.0, MeasurementUnit.G),
-              Nutrient("saturatedFat", 3.0, MeasurementUnit.G),
-              Nutrient("carbohydrates", 20.0, MeasurementUnit.G),
-              Nutrient("netCarbohydrates", 15.0, MeasurementUnit.G),
-              Nutrient("sugar", 5.0, MeasurementUnit.G),
-              Nutrient("cholesterol", 0.0, MeasurementUnit.MG),
-              Nutrient("sodium", 0.0, MeasurementUnit.MG),
-              Nutrient("protein", 15.0, MeasurementUnit.G),
-              Nutrient("vitaminC", 0.0, MeasurementUnit.MG),
-              Nutrient("manganese", 0.0, MeasurementUnit.UG),
-              Nutrient("fiber", 2.0, MeasurementUnit.G),
-              Nutrient("vitaminB6", 0.0, MeasurementUnit.MG),
-              Nutrient("copper", 0.0, MeasurementUnit.UG),
-              Nutrient("vitaminB1", 0.0, MeasurementUnit.MG),
-              Nutrient("folate", 0.0, MeasurementUnit.UG),
-              Nutrient("potassium", 0.0, MeasurementUnit.MG),
-              Nutrient("magnesium", 0.0, MeasurementUnit.MG),
-              Nutrient("vitaminB3", 0.0, MeasurementUnit.MG),
-              Nutrient("vitaminB5", 0.0, MeasurementUnit.MG),
-              Nutrient("vitaminB2", 0.0, MeasurementUnit.MG),
-              Nutrient("iron", 0.0, MeasurementUnit.MG),
-              Nutrient("calcium", 0.0, MeasurementUnit.MG),
-              Nutrient("vitaminA", 0.0, MeasurementUnit.IU),
-              Nutrient("zinc", 0.0, MeasurementUnit.MG),
-              Nutrient("phosphorus", 0.0, MeasurementUnit.MG),
-              Nutrient("vitaminK", 0.0, MeasurementUnit.UG),
-              Nutrient("selenium", 0.0, MeasurementUnit.UG),
-              Nutrient("vitaminE", 0.0, MeasurementUnit.IU)))
+      Ingredient(
+          name = "Test",
+          id = 0,
+          amount = 1.0,
+          unit = MeasurementUnit.UNIT,
+          nutritionalInformation =
+              NutritionalInformation(
+                  mutableListOf(
+                      Nutrient("totalWeight", 100.0, MeasurementUnit.G),
+                      Nutrient("calories", 200.0, MeasurementUnit.CAL),
+                      Nutrient("fat", 10.0, MeasurementUnit.G),
+                      Nutrient("saturatedFat", 3.0, MeasurementUnit.G),
+                      Nutrient("carbohydrates", 20.0, MeasurementUnit.G),
+                      Nutrient("netCarbohydrates", 15.0, MeasurementUnit.G),
+                      Nutrient("sugar", 5.0, MeasurementUnit.G),
+                      Nutrient("cholesterol", 0.0, MeasurementUnit.MG),
+                      Nutrient("sodium", 0.0, MeasurementUnit.MG),
+                      Nutrient("protein", 15.0, MeasurementUnit.G),
+                      Nutrient("vitaminC", 0.0, MeasurementUnit.MG),
+                      Nutrient("manganese", 0.0, MeasurementUnit.UG),
+                      Nutrient("fiber", 2.0, MeasurementUnit.G),
+                      Nutrient("vitaminB6", 0.0, MeasurementUnit.MG),
+                      Nutrient("copper", 0.0, MeasurementUnit.UG),
+                      Nutrient("vitaminB1", 0.0, MeasurementUnit.MG),
+                      Nutrient("folate", 0.0, MeasurementUnit.UG),
+                      Nutrient("potassium", 0.0, MeasurementUnit.MG),
+                      Nutrient("magnesium", 0.0, MeasurementUnit.MG),
+                      Nutrient("vitaminB3", 0.0, MeasurementUnit.MG),
+                      Nutrient("vitaminB5", 0.0, MeasurementUnit.MG),
+                      Nutrient("vitaminB2", 0.0, MeasurementUnit.MG),
+                      Nutrient("iron", 0.0, MeasurementUnit.MG),
+                      Nutrient("calcium", 0.0, MeasurementUnit.MG),
+                      Nutrient("vitaminA", 0.0, MeasurementUnit.IU),
+                      Nutrient("zinc", 0.0, MeasurementUnit.MG),
+                      Nutrient("phosphorus", 0.0, MeasurementUnit.MG),
+                      Nutrient("vitaminK", 0.0, MeasurementUnit.UG),
+                      Nutrient("selenium", 0.0, MeasurementUnit.UG),
+                      Nutrient("vitaminE", 0.0, MeasurementUnit.IU))))
 
-  private fun meal(nutritionalInformation: NutritionalInformation) =
+  private fun meal(ingredient: Ingredient) =
       Meal(
           name = "Steak & Veggie",
-          ingredients = mutableListOf(),
+          ingredients = mutableListOf(ingredient),
           occasion = MealOccasion.DINNER,
           mealID = 20,
-          nutritionalInformation = nutritionalInformation)
+          nutritionalInformation = NutritionalInformation(mutableListOf()))
 
   private fun setup(meal: Meal) {
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
@@ -38,8 +38,7 @@ class AddMealFlowTest {
       NavHost(navController = navController, startDestination = Route.Home) {
         composable(Route.Home) { HomeScreen() }
         composable(Route.AddMeal) {
-          AddMealFlow(
-              navigation::goBack, navigation::navigateToHome, "testUserID", MealViewModel(mockk()))
+          AddMealFlow(navigation::goBack, navigation::navigateToHome, MealViewModel(mockk()))
         }
       }
       navigation.navigateToAddMeal()

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/OverviewScreenTest.kt
@@ -52,7 +52,7 @@ class OverviewTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSu
         }
 
         composable(Route.AddMeal) {
-          AddMealFlow(goBack = {}, navigateToHome = {}, userID = "Test", mockk(relaxed = true))
+          AddMealFlow(goBack = {}, navigateToHome = {}, mockk(relaxed = true))
         }
       }
     }

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/MealViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/MealViewModelTest.kt
@@ -105,8 +105,8 @@ class MealViewModelTest {
     viewModel.addIngredient(ingredient)
     viewModel.removeIngredient(ingredient)
 
-    assert(viewModel.meal.value?.ingredients?.contains(ingredient) == false)
-    assert(viewModel.meal.value?.nutritionalInformation?.getNutrient("calories")?.amount == 0.0)
+    assert(!viewModel.meal.value.ingredients.contains(ingredient))
+    assert(viewModel.meal.value.nutritionalInformation.getNutrient("calories") == null)
   }
 
   @Test
@@ -158,13 +158,7 @@ class MealViewModelTest {
         Meal(
             name = "Meal Name",
             mealID = 123,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(
-                        Nutrient(
-                            nutrientType = "calories",
-                            amount = 100.0,
-                            unit = MeasurementUnit.CAL))),
+            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -174,7 +168,7 @@ class MealViewModelTest {
                         unit = MeasurementUnit.G,
                         nutritionalInformation =
                             NutritionalInformation(
-                                mutableListOf(Nutrient("calories", 0.0, MeasurementUnit.CAL))))),
+                                mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.CAL))))),
             occasion = MealOccasion.BREAKFAST)
     viewModel.setMealData(meal)
     assert(viewModel.meal.value == meal)

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -54,7 +54,7 @@ class MainActivity : ComponentActivity() {
             // make sure the create is clear
 
             // check reall created
-            AddMealFlow(navigation::goBack, navigation::navigateToHome, "testUserID")
+            AddMealFlow(navigation::goBack, navigation::navigateToHome)
           }
         }
       }

--- a/app/src/main/java/com/github/se/polyfit/model/ingredient/Ingredient.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/ingredient/Ingredient.kt
@@ -20,6 +20,10 @@ data class Ingredient(
     val nutritionalInformation: NutritionalInformation = NutritionalInformation(mutableListOf()),
 ) {
 
+  fun deepCopy(): Ingredient {
+    return Ingredient(name, id, amount, unit, nutritionalInformation.deepCopy())
+  }
+
   companion object {
     fun serialize(ingredient: Ingredient): Map<String, Any> {
       val map = mutableMapOf<String, Any>()

--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -25,6 +25,32 @@ data class Meal(
     updateMeal()
   }
 
+  fun deepCopy(
+      occasion: MealOccasion = this.occasion,
+      name: String = this.name,
+      mealID: Long = this.mealID,
+      mealTemp: Double = this.mealTemp,
+      ingredients: MutableList<Ingredient> = this.ingredients,
+      firebaseId: String = this.firebaseId,
+      createdAt: LocalDate = this.createdAt,
+      tags: MutableList<MealTag> = this.tags
+  ): Meal {
+    val newIngredients = ingredients.map { it.deepCopy() }.toMutableList()
+    val newTags = tags.map { it.copy() }.toMutableList()
+    val newNutritionalInformation = NutritionalInformation(mutableListOf())
+
+    return Meal(
+        occasion = occasion,
+        name = name,
+        mealID = mealID,
+        mealTemp = mealTemp,
+        nutritionalInformation = newNutritionalInformation,
+        ingredients = newIngredients,
+        firebaseId = firebaseId,
+        createdAt = createdAt,
+        tags = newTags)
+  }
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is Meal) return false

--- a/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
@@ -16,7 +16,6 @@ import com.github.se.polyfit.viewmodel.meal.MealViewModel
 fun AddMealFlow(
     goBack: () -> Unit,
     navigateToHome: () -> Unit,
-    userID: String,
     mealViewModel: MealViewModel = hiltViewModel<MealViewModel>()
 ) {
 

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/AdditionalMealInfoScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/AdditionalMealInfoScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
 import com.github.se.polyfit.ui.components.button.PrimaryButton
 import com.github.se.polyfit.ui.components.scaffold.SimpleTopBar
@@ -32,7 +31,7 @@ fun AdditionalMealInfoScreen(
     navigateBack: () -> Unit,
     navigateForward: () -> Unit
 ) {
-  val meal by mealViewModel.meal.collectAsState(initial = Meal.default())
+  val meal by mealViewModel.meal.collectAsState()
   val occasion = meal.occasion
   val mealTags = meal.tags
 
@@ -62,17 +61,6 @@ private fun BottomBar(isComplete: Boolean, navigateForward: () -> Unit) {
         Box(
             modifier = Modifier.fillMaxWidth().testTag("DoneBox"),
             contentAlignment = Alignment.Center) {
-              //              Button(
-              //                  onClick = {
-              //                    navigateForward()
-              //                    Log.v("Additional Meal Information", "Done")
-              //                  },
-              //                  enabled = isComplete,
-              //                  modifier = Modifier.width(200.dp).testTag("DoneButton"),
-              //                  colors = ButtonDefaults.buttonColors(containerColor =
-              // PrimaryPurple)) {
-              //                    Text(text = "Done", fontSize = 24.sp)
-              //                  }
               PrimaryButton(
                   onClick = {
                     navigateForward()

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/NutritionScreen.kt
@@ -32,7 +32,6 @@ import com.github.se.polyfit.ui.theme.PrimaryPink
 import com.github.se.polyfit.ui.theme.PrimaryPurple
 import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NutritionScreen(
     mealViewModel: MealViewModel,
@@ -40,13 +39,12 @@ fun NutritionScreen(
     navigateForward: () -> Unit
 ) {
   val isComplete by mealViewModel.isComplete.collectAsState()
-
   Scaffold(
       topBar = { TopBar(navigateBack = navigateBack) },
       bottomBar = {
         BottomBar(
             setMeal = mealViewModel::setMeal,
-            isComplete = isComplete ?: false,
+            isComplete = isComplete,
             navigateForward = navigateForward)
       }) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) { NutritionalInformation(mealViewModel) }

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -40,28 +40,32 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
       mealID: Long = _meal.value.mealID,
       mealTemp: Double = _meal.value.mealTemp,
       ingredients: MutableList<Ingredient> = _meal.value.ingredients,
-      nutritionalInformation: NutritionalInformation = _meal.value.nutritionalInformation,
       firebaseID: String = _meal.value.firebaseId,
-      createdAt: LocalDate = _meal.value.createdAt
+      createdAt: LocalDate = _meal.value.createdAt,
+      tags: MutableList<MealTag> = _meal.value.tags
   ) {
+    // When we make a new Meal, we add all the ingredient values into nutritionalInfo. If we pass
+    // existing values, then its double adding
+    val newNutritionalInformation = NutritionalInformation(mutableListOf())
     _meal.value =
         Meal(
             mealOccasion,
             name,
             mealID,
             mealTemp,
-            nutritionalInformation,
+            newNutritionalInformation,
             ingredients,
             firebaseID,
-            createdAt)
+            createdAt,
+            tags)
   }
 
   fun setMealCreatedAt(createdAt: LocalDate) {
-    _meal.value = _meal.value?.copy(createdAt = createdAt)!!
+    _meal.value = _meal.value.deepCopy(createdAt = createdAt)
   }
 
   fun setMealOccasion(occasion: MealOccasion) {
-    _meal.value = _meal.value?.copy(occasion = occasion)!!
+    _meal.value = _meal.value.deepCopy(occasion = occasion)
   }
 
   fun setMeal() {
@@ -80,21 +84,21 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
 
   fun addIngredient(ingredient: Ingredient) {
     val updatedIngredients = _meal.value.ingredients.toMutableList().apply { add(ingredient) }
-    _meal.value = _meal.value.copy(ingredients = updatedIngredients)
+    _meal.value = _meal.value.deepCopy(ingredients = updatedIngredients)
   }
 
   fun removeIngredient(ingredient: Ingredient) {
     val updatedIngredients = _meal.value.ingredients.toMutableList().apply { remove(ingredient) }
 
-    _meal.value = _meal.value.copy(ingredients = updatedIngredients)
+    _meal.value = _meal.value.deepCopy(ingredients = updatedIngredients)
   }
 
   fun addTag(tag: MealTag) {
-    _meal.value!!.tags.add(tag)
+    _meal.value.tags.add(tag)
   }
 
   fun removeTag(tag: MealTag) {
-    _meal.value!!.tags.remove(tag)
+    _meal.value.tags.remove(tag)
   }
 
   // TODO: This can be removed once we are properly using a new ViewModel for each Meal


### PR DESCRIPTION
Fixing bugs within the AddMeal flow:
- Nutrients are not reflecting properly. It's because every time we copy a meal, we copy the nutritional value and then add the ingredient nutrients, which double counts. The fix was to use a `deepCopy` with an empty NutritionalInformation object, so it reflects only the ingredients in the copied meal.
- Meal Occasion not showing up even when selected. This was because we were setting `initial = Meal.default()` on this page, even though it should have a value already. Removing this fixes that.
- Tags disappearing: MealViewModel's updateMealData didn't include the tags, so it removed them every time it got called to a default empty list.
- UserId is not used at all in the AddMealFlow, so removed

**Take away / advice**: When creating a Meal, never set the nutrition straight into the nutrition fact. Add ingredients and let the constructor do it.