### PR TITLE
BUGFIX: Only update nutritional information if empty

### DIFF
--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -22,7 +22,10 @@ data class Meal(
   init {
     require(mealID >= 0)
 
-    updateMeal()
+    // TODO: https://github.com/swent-group10/polyfit/issues/177
+    if (nutritionalInformation.nutrients.isEmpty()) {
+      updateMeal()
+    }
   }
 
   fun deepCopy(

--- a/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
@@ -200,11 +200,7 @@ class MealTest {
             name = "eggs",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(
-                        Nutrient("calories", 100.0, MeasurementUnit.CAL),
-                        Nutrient("calcium", 1.0, MeasurementUnit.G))),
+            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -217,7 +213,7 @@ class MealTest {
                                 Nutrient("calories", 100.0, MeasurementUnit.CAL),
                                 Nutrient("calcium", 1.0, MeasurementUnit.G))))))
 
-    assertEquals(200.0, meal.calculateTotalCalories(), 0.001)
+    assertEquals(100.0, meal.calculateTotalCalories(), 0.001)
   }
 
   @Test
@@ -228,11 +224,7 @@ class MealTest {
             name = "eggs",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(
-                        Nutrient("calcium", 1.0, MeasurementUnit.G),
-                        Nutrient("calories", 100.0, MeasurementUnit.CAL))),
+            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -245,6 +237,6 @@ class MealTest {
                                 Nutrient("calcium", 1.0, MeasurementUnit.G),
                                 Nutrient("calories", 100.0, MeasurementUnit.CAL))))))
 
-    assertEquals(2.0, meal.calculateTotalNutrient("calcium"), 0.001)
+    assertEquals(1.0, meal.calculateTotalNutrient("calcium"), 0.001)
   }
 }


### PR DESCRIPTION
We're having issues with double counting nutrients. This is a temp fix before M2 to prevent meals with nutritional information from getting updated in construction. It will be changed later to prevent allowing nutritional information to be passed as a parameter.

See https://github.com/swent-group10/polyfit/issues/177