### PR TITLE
UI/ Helpers for CreatePostScreen

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/dialog/LocationPermissionScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/dialog/LocationPermissionScreen.kt
@@ -1,0 +1,16 @@
+package com.github.se.polyfit.ui.components.dialog
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class LocationPermissionScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<LocationPermissionScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("LocationPermissionDialog") }) {
+
+  val title: KNode = onNode { hasTestTag("Title") }
+  val message: KNode = onNode { hasTestTag("Message") }
+  val approveButton: KNode = onNode { hasTestTag("ApproveButton") }
+  val denyButton: KNode = onNode { hasTestTag("DenyButton") }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/dialog/LocationPermissionTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/dialog/LocationPermissionTest.kt
@@ -1,0 +1,75 @@
+package com.github.se.polyfit.ui.components.dialog
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.base.Verify.verify
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.TestCase
+import kotlin.test.Test
+import org.junit.Before
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocationPermissionTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  val mockFunction: () -> Unit = mockk()
+
+  @Before
+  fun setup() {
+    every { mockFunction() } just Runs
+    composeTestRule.setContent {
+      LocationPermissionDialog(onApprove = mockFunction, onDeny = mockFunction)
+    }
+  }
+
+  @Test
+  fun everythingIsDisplayed() {
+    ComposeScreen.onComposeScreen<LocationPermissionScreen>(composeTestRule) {
+      title {
+        assertIsDisplayed()
+        assertTextEquals("Location Permission Request")
+      }
+
+      message {
+        assertIsDisplayed()
+        assertTextEquals(
+            "Your post will be visible to others around you. Allow Polyfit to access your location?")
+      }
+
+      approveButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertTextEquals(" Allow ")
+      }
+
+      denyButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        assertTextEquals(" Cancel ")
+      }
+    }
+  }
+
+  @Test
+  fun approveButtonClicked() {
+    ComposeScreen.onComposeScreen<LocationPermissionScreen>(composeTestRule) {
+      approveButton { performClick() }
+      verify { mockFunction() }
+    }
+  }
+
+  @Test
+  fun denyButtonClicked() {
+    ComposeScreen.onComposeScreen<LocationPermissionScreen>(composeTestRule) {
+      denyButton { performClick() }
+      verify { mockFunction() }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorScreen.kt
@@ -1,0 +1,18 @@
+package com.github.se.polyfit.ui.components.selector
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class MealSelectorScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<MealSelectorScreen>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("MealSelector") }) {
+
+  val mealSelectorRow: KNode = child { hasTestTag("MealSelectorRow") }
+  val searchMealBar: KNode = child { hasTestTag("SearchMealBar") }
+  val mealDetails: KNode = child { hasTestTag("MealDetails") }
+  val carbs: KNode = onNode { hasTestTag("Carbs") }
+  val protein: KNode = onNode { hasTestTag("Protein") }
+  val fat: KNode = onNode { hasTestTag("Fat") }
+  val ingredient: KNode = onNode { hasTestTag("Ingredient") }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
@@ -1,0 +1,116 @@
+package com.github.se.polyfit.ui.components.selector
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
+import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import com.github.se.polyfit.ui.components.textField.MealInputTextFieldScreen
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.TestCase
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MealSelectorTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val mockSetPostMeal: (Meal) -> Unit = mockk(relaxed = true)
+  private val mockSetSelectedMeal: (Meal) -> Unit = mockk(relaxed = true)
+  private var selectedMeal: Meal = Meal.default()
+
+  fun setup(meals: List<Meal> = listOf()) {
+    composeTestRule.setContent {
+      MealSelector(
+          selectedMeal = selectedMeal,
+          setSelectedMeal = mockSetSelectedMeal,
+          meals = meals,
+          setPostMeal = mockSetPostMeal)
+    }
+  }
+
+  @Test
+  fun defaultDisplay() {
+    setup()
+
+    ComposeScreen.onComposeScreen<MealSelectorScreen>(composeTestRule) {
+      mealSelectorRow {
+        assertIsDisplayed()
+        assertTextContains("Share your recipe")
+      }
+
+      searchMealBar { assertDoesNotExist() }
+      mealDetails { assertDoesNotExist() }
+      carbs { assertDoesNotExist() }
+      protein { assertDoesNotExist() }
+      fat { assertDoesNotExist() }
+      ingredient { assertDoesNotExist() }
+    }
+  }
+
+  @Test
+  fun selectingMealReplacesSelector() {
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    meal.addIngredient(
+        Ingredient(
+            "milk",
+            1,
+            102.0,
+            MeasurementUnit.MG,
+            NutritionalInformation(mutableListOf(Nutrient("calories", 1.0, MeasurementUnit.G)))))
+    setup(listOf(meal))
+
+    ComposeScreen.onComposeScreen<MealSelectorScreen>(composeTestRule) {
+      mealSelectorRow {
+        assertIsDisplayed()
+        assertTextContains("Share your recipe")
+        performClick()
+      }
+    }
+
+    ComposeScreen.onComposeScreen<MealInputTextFieldScreen>(composeTestRule) {
+      searchMealBar {
+        assertIsDisplayed()
+        performClick()
+      }
+      meal {
+        assertIsDisplayed()
+        performClick()
+      }
+    }
+
+    verify { mockSetSelectedMeal(meal) }
+  }
+
+  @Test
+  fun selectedMealIsDisplayed() {
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    meal.addIngredient(
+        Ingredient(
+            "milk",
+            1,
+            102.0,
+            MeasurementUnit.MG,
+            NutritionalInformation(mutableListOf(Nutrient("calories", 1.0, MeasurementUnit.G)))))
+    selectedMeal = meal
+    setup()
+
+    ComposeScreen.onComposeScreen<MealSelectorScreen>(composeTestRule) {
+      mealSelectorRow {
+        assertIsDisplayed()
+        assertTextContains("eggs")
+        assertTextContains("1.0 kcal")
+      }
+
+      carbs { assertIsDisplayed() }
+      protein { assertIsDisplayed() }
+      fat { assertIsDisplayed() }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldScreen.kt
@@ -1,0 +1,18 @@
+package com.github.se.polyfit.ui.components.textField
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class MealInputTextFieldScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<MealInputTextFieldScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("SearchMealBar") }) {
+
+  val searchMealBar: KNode = onNode { hasTestTag("SearchMealBar") }
+  val placeholder: KNode = searchMealBar.child { hasText("Enter a meal…") }
+  val scrollableList: KNode = onNode { hasTestTag("MealSearchScrollableList") }
+  val meal: KNode = onNode { hasTestTag("Meal") }
+  val mealName: KNode = meal.child { hasTestTag("MealName") }
+  val mealCalories: KNode = meal.child { hasTestTag("MealCalories") }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldTest.kt
@@ -1,0 +1,101 @@
+package com.github.se.polyfit.ui.components.textField
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.model.meal.MealOccasion
+import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
+import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.TestCase
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MealInputTextFieldTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  val mockCollapse: () -> Unit = mockk()
+  val mockMealChange: (Meal) -> Unit = mockk()
+
+  fun setup(meals: List<Meal> = listOf()) {
+    every { mockCollapse() } just Runs
+    every { mockMealChange(any()) } just Runs
+
+    composeTestRule.setContent {
+      MealInputTextField(
+          meals = meals, onCollapseSearchBar = mockCollapse, onMealChange = mockMealChange)
+    }
+  }
+
+  @Test
+  fun everythingIsDisplayed() {
+    setup()
+    ComposeScreen.onComposeScreen<MealInputTextFieldScreen>(composeTestRule) {
+      searchMealBar {
+        assertExists()
+        assertIsDisplayed()
+      }
+
+      placeholder {
+        assertExists()
+        assertIsDisplayed()
+      }
+
+      meal { assertDoesNotExist() }
+
+      mealName { assertDoesNotExist() }
+
+      mealCalories { assertDoesNotExist() }
+
+      scrollableList { assertDoesNotExist() }
+    }
+  }
+
+  @Test
+  fun mealsDisplayWhenSearched() {
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    meal.addIngredient(
+        Ingredient(
+            "milk",
+            1,
+            102.0,
+            MeasurementUnit.MG,
+            NutritionalInformation(mutableListOf(Nutrient("calories", 1.0, MeasurementUnit.G)))))
+    setup(listOf(meal))
+
+    ComposeScreen.onComposeScreen<MealInputTextFieldScreen>(composeTestRule) {
+      searchMealBar {
+        assertExists()
+        assertIsDisplayed()
+        performClick()
+      }
+
+      placeholder {
+        assertExists()
+        assertIsDisplayed()
+      }
+
+      meal {
+        assertExists()
+        assertIsDisplayed()
+        assertTextContains("eggs")
+        assertTextContains("1.0 kcal")
+        performClick()
+      }
+
+      verify(exactly = 1) { mockMealChange(meal) }
+      verify(exactly = 1) { mockCollapse() }
+
+      scrollableList { assertExists() }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/post/CreatePostViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/post/CreatePostViewModelTest.kt
@@ -83,7 +83,7 @@ class CreatePostViewModelTest {
 
   @Test
   fun getCarbsReturnsCarbsAmount() {
-    val carbs = Nutrient("carb", 10.0, MeasurementUnit.G)
+    val carbs = Nutrient("carbohydrates", 10.0, MeasurementUnit.G)
     val meal =
         Meal.default().copy(nutritionalInformation = NutritionalInformation(mutableListOf(carbs)))
     val post = Post.default().copy(meal = meal)

--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -2,6 +2,7 @@ package com.github.se.polyfit.model.meal
 
 import android.util.Log
 import com.github.se.polyfit.model.ingredient.Ingredient
+import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import java.time.LocalDate
 
@@ -107,6 +108,21 @@ data class Meal(
     return name.isNotEmpty() &&
         ingredients.isNotEmpty() &&
         nutritionalInformation.nutrients.isNotEmpty()
+  }
+
+  fun getNutrient(nutrientType: String): Nutrient? {
+    return this.nutritionalInformation.getNutrient(nutrientType)
+  }
+
+  fun getMacros(): Map<String, Double> {
+    val macros = mutableMapOf<String, Double>()
+    val protein = getNutrient("protein")?.amount ?: 0.0
+    val fat = getNutrient("fat")?.amount ?: 0.0
+    val carbs = getNutrient("carbohydrates")?.amount ?: 0.0
+    macros["protein"] = protein
+    macros["fat"] = fat
+    macros["carbohydrates"] = carbs
+    return macros
   }
 
   private fun updateMeal() {

--- a/app/src/main/java/com/github/se/polyfit/model/post/Post.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/post/Post.kt
@@ -28,15 +28,15 @@ data class Post(
   }
 
   fun getCarbs(): Nutrient? {
-    return meal.nutritionalInformation.getNutrient("carb")
+    return meal.getNutrient("carbohydrates")
   }
 
   fun getFat(): Nutrient? {
-    return meal.nutritionalInformation.getNutrient("fat")
+    return meal.getNutrient("fat")
   }
 
   fun getProtein(): Nutrient? {
-    return meal.nutritionalInformation.getNutrient("protein")
+    return meal.getNutrient("protein")
   }
 
   fun serialize(): Map<String, Any> {

--- a/app/src/main/java/com/github/se/polyfit/ui/components/dialog/LocationPermissionDialog.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/dialog/LocationPermissionDialog.kt
@@ -1,0 +1,64 @@
+package com.github.se.polyfit.ui.components.dialog
+
+import android.content.Context
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+import com.github.se.polyfit.R
+import com.github.se.polyfit.ui.theme.PrimaryPurple
+
+@Composable
+fun LocationPermissionDialog(onDeny: () -> Unit, onApprove: () -> Unit) {
+  val context: Context = LocalContext.current
+  AlertDialog(
+      onDismissRequest = onDeny,
+      title = {
+        Text(
+            context.getString(R.string.locationPermissionRequestTitle),
+            modifier = Modifier.testTag("Title"),
+        )
+      },
+      modifier = Modifier.testTag("LocationPermissionDialog"),
+      text = {
+        Text(
+            text = context.getString(R.string.locationPermissionRequestMessage),
+            fontSize = 16.sp,
+            modifier = Modifier.testTag("Message"))
+      },
+      confirmButton = {
+        Button(
+            onClick = onApprove,
+            border = BorderStroke(3.dp, PrimaryPurple),
+            shape = RoundedCornerShape(20.dp),
+            modifier = Modifier.testTag("ApproveButton"),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = PrimaryPurple, contentColor = Color.White)) {
+              Text(context.getString(R.string.acceptRequest), fontSize = 16.sp)
+            }
+      },
+      dismissButton = {
+        Button(
+            onClick = onDeny,
+            border = BorderStroke(3.dp, PrimaryPurple),
+            shape = RoundedCornerShape(20.dp),
+            modifier = Modifier.testTag("DenyButton"),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = Color.White, contentColor = PrimaryPurple)) {
+              Text(text = context.getString(R.string.denyRequest), fontSize = 16.sp)
+            }
+      },
+      properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = false))
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/components/scaffold/CenteredTopBar.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/scaffold/CenteredTopBar.kt
@@ -1,0 +1,42 @@
+package com.github.se.polyfit.ui.components.scaffold
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import com.github.se.polyfit.ui.theme.PrimaryPurple
+import com.github.se.polyfit.ui.utils.titleCase
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CenteredTopBar(title: String, titleColor: Color = PrimaryPurple, navigateBack: () -> Unit) {
+  CenterAlignedTopAppBar(
+      title = {
+        Text(
+            title,
+            modifier = Modifier.testTag("${titleCase(title)} Title"),
+            color = titleColor,
+            fontSize = MaterialTheme.typography.headlineMedium.fontSize)
+      },
+      navigationIcon = {
+        IconButton(
+            onClick = { navigateBack() },
+            content = {
+              Icon(
+                  imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                  contentDescription = "Back",
+                  modifier = Modifier.testTag("BackButton"),
+                  tint = PrimaryPurple)
+            },
+            modifier = Modifier.testTag("BackButton"))
+      },
+      modifier = Modifier.testTag("TopBar"))
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
@@ -1,0 +1,162 @@
+package com.github.se.polyfit.ui.components.selector
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.polyfit.R
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.ui.components.GradientBox
+import com.github.se.polyfit.ui.components.textField.MealInputTextField
+import com.github.se.polyfit.ui.theme.PrimaryPurple
+import com.github.se.polyfit.ui.theme.SecondaryGrey
+
+@Composable
+fun MealSelector(
+    selectedMeal: Meal,
+    setSelectedMeal: (Meal) -> Unit,
+    meals: List<Meal>,
+    setPostMeal: (Meal) -> Unit
+) {
+  val context = LocalContext.current
+  var showMealSearch by remember { mutableStateOf(false) }
+  val isDisplayMealDetails by
+      remember(selectedMeal) { derivedStateOf { selectedMeal.isComplete() } }
+
+  Box(modifier = Modifier.testTag("MealSelector")) {
+    if (!showMealSearch) {
+      Row(
+          modifier =
+              Modifier.padding(start = 12.dp, top = 20.dp)
+                  .fillMaxWidth()
+                  .testTag("MealSelectorRow")
+                  .clickable {
+                    showMealSearch = true
+                    setSelectedMeal(Meal.default())
+                  }) {
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = "Star",
+                tint = SecondaryGrey,
+                modifier = Modifier.padding(end = 20.dp))
+
+            if (!isDisplayMealDetails) {
+              Text(
+                  text = context.getString(R.string.shareRecipePlaceholder),
+                  color = SecondaryGrey,
+                  fontSize = 20.sp,
+              )
+            } else {
+              Text(
+                  text = selectedMeal.name,
+                  fontSize = 20.sp,
+                  modifier = Modifier.weight(1f),
+              )
+              Text(
+                  text = "${selectedMeal.calculateTotalCalories()} kcal",
+                  fontSize = 20.sp,
+                  modifier = Modifier.weight(1f).padding(end = 20.dp),
+                  textAlign = TextAlign.End,
+              )
+            }
+          }
+    } else {
+      MealInputTextField(
+          meals = meals,
+          onCollapseSearchBar = { showMealSearch = false },
+          onMealChange = {
+            setSelectedMeal(it)
+            setPostMeal(it)
+          })
+    }
+    if (isDisplayMealDetails) {
+      MealDetails(selectedMeal, Modifier.padding(top = 10.dp))
+    }
+  }
+}
+
+@Composable
+fun MealDetails(meal: Meal, modifier: Modifier = Modifier) {
+  Box(modifier = modifier.fillMaxWidth().testTag("MealDetails")) {
+    Column(modifier = Modifier.fillMaxWidth(0.75f).align(Alignment.Center)) {
+      LazyColumn(modifier = Modifier.heightIn(max = 200.dp)) {
+        items(meal.ingredients) { ingredient ->
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(4.dp).testTag("Ingredient"),
+              verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = ingredient.name,
+                    modifier = Modifier.weight(1f).padding(start = 10.dp),
+                    fontSize = 16.sp,
+                    color = SecondaryGrey)
+
+                Text(
+                    text = "${ingredient.amount} ${ingredient.unit.toString().lowercase()}",
+                    modifier = Modifier.weight(1f).padding(end = 10.dp),
+                    textAlign = TextAlign.End,
+                    fontSize = 16.sp,
+                    color = SecondaryGrey)
+              }
+          HorizontalDivider(color = Color.LightGray)
+        }
+      }
+
+      Spacer(modifier = Modifier.height(10.dp))
+
+      Row(modifier = Modifier.align(Alignment.CenterHorizontally)) {
+        val macros = meal.getMacros()
+        val nutrients =
+            listOf(
+                Pair("Carbs", macros["carbohydrates"]),
+                Pair("Fat", macros["fat"]),
+                Pair("Protein", macros["protein"]),
+            )
+
+        nutrients.forEach { (nutrientName, amount) ->
+          GradientBox(
+              outerModifier = Modifier.padding(horizontal = 10.dp),
+              innerModifier =
+                  Modifier.heightIn(min = 80.dp, max = 80.dp).widthIn(max = 80.dp, min = 80.dp),
+              round = 50.0) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                  Column(
+                      horizontalAlignment = Alignment.CenterHorizontally,
+                      modifier = Modifier.testTag(nutrientName)) {
+                        Text(text = "$amount g", color = SecondaryGrey)
+                        Text(text = nutrientName, color = PrimaryPurple, fontSize = 15.sp)
+                      }
+                }
+              }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -143,8 +143,7 @@ fun MealDetails(meal: Meal, modifier: Modifier = Modifier) {
         nutrients.forEach { (nutrientName, amount) ->
           GradientBox(
               outerModifier = Modifier.padding(horizontal = 10.dp),
-              innerModifier =
-                  Modifier.heightIn(min = 80.dp, max = 80.dp).widthIn(max = 80.dp, min = 80.dp),
+              innerModifier = Modifier.size(80.dp),
               round = 50.0) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                   Column(

--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/PictureSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/PictureSelector.kt
@@ -1,0 +1,30 @@
+package com.github.se.polyfit.ui.components.selector
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.se.polyfit.ui.theme.PurpleGrey80
+
+@Composable
+fun PictureSelector(modifier: Modifier = Modifier) {
+  // Not sure if we are going to use a picture for the post, so this is just a placeholder
+  Box(
+      modifier = modifier.fillMaxWidth().testTag("PictureSelector"),
+      contentAlignment = Alignment.Center) {
+        Box(
+            modifier =
+                Modifier.size(200.dp)
+                    .background(color = PurpleGrey80, shape = RoundedCornerShape(20.dp)),
+            contentAlignment = Alignment.Center) {
+              Text("Picture Placeholder")
+            }
+      }
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/components/textField/MealInputTextField.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/textField/MealInputTextField.kt
@@ -1,0 +1,101 @@
+package com.github.se.polyfit.ui.components.textField
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.polyfit.R
+import com.github.se.polyfit.model.meal.Meal
+import com.github.se.polyfit.ui.theme.SecondaryGrey
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MealInputTextField(
+    meals: List<Meal>,
+    onCollapseSearchBar: () -> Unit = {},
+    onMealChange: (Meal) -> Unit = {}
+) {
+  val context = LocalContext.current
+  var showIngredientSearch by remember { mutableStateOf(false) }
+  var searchText by remember { mutableStateOf("") }
+  var searchResults by remember { mutableStateOf(meals) }
+
+  // Set the search bar to be at most 5 items tall, then scroll
+  val maxHeight = (74 + minOf(5, searchResults.size) * 41).dp
+
+  SearchBar(
+      modifier =
+          Modifier.padding(start = 20.dp, end = 20.dp)
+              .fillMaxWidth()
+              .heightIn(max = maxHeight)
+              .testTag("SearchMealBar"),
+      query = searchText,
+      onQueryChange = {
+        searchText = it
+        showIngredientSearch = true
+      },
+      onSearch = {
+        searchResults = meals.filter { meal -> meal.name.contains(searchText, ignoreCase = true) }
+      },
+      active = showIngredientSearch,
+      onActiveChange = { showIngredientSearch = it },
+      leadingIcon = {
+        Icon(Icons.Filled.Search, contentDescription = "search", tint = SecondaryGrey)
+      },
+      placeholder = {
+        Text(
+            text = context.getString(R.string.enterMealPlaceholder),
+            color = SecondaryGrey,
+            style = TextStyle(fontSize = 17.sp),
+            modifier = Modifier.testTag("Placeholder"))
+      }) {
+        LazyColumn(
+            modifier = Modifier.testTag("MealSearchScrollableList"),
+        ) {
+          items(searchResults) { meal ->
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth().padding(8.dp).testTag("Meal").clickable {
+                      onMealChange(meal)
+                      onCollapseSearchBar()
+                    },
+                verticalAlignment = Alignment.CenterVertically) {
+                  Text(
+                      text = meal.name,
+                      modifier = Modifier.weight(1f).padding(start = 10.dp).testTag("MealName"),
+                      fontSize = 16.sp,
+                  )
+                  Text(
+                      text = meal.calculateTotalCalories().toString() + " kcal",
+                      modifier = Modifier.weight(1f).padding(end = 10.dp).testTag("MealCalories"),
+                      textAlign = TextAlign.End,
+                      fontSize = 16.sp)
+                }
+            HorizontalDivider()
+          }
+        }
+      }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,10 @@
     <string name="description">"Description"</string>
     <string name="nutrient">"Nutrient"</string>
     <string name="no_recorded_meals">"No recorded meals"</string>
+    <string name="locationPermissionRequestTitle">"Location Permission Request"</string>
+    <string name="locationPermissionRequestMessage">"Your post will be visible to others around you. Allow Polyfit to access your location?"</string>
+    <string name="acceptRequest">" Allow "</string>
+    <string name="denyRequest">" Cancel "</string>
+    <string name="shareRecipePlaceholder">"Share your recipe"</string>
+    <string name="enterMealPlaceholder">"Enter a meal…"</string>
 </resources>

--- a/app/src/test/java/com/github/se/polyfit/data/post/PostTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/data/post/PostTest.kt
@@ -13,7 +13,7 @@ class PostTest {
 
   @Test
   fun `getCarbs returns correct nutrient when present`() {
-    val expected = Nutrient("carb", 100.0, MeasurementUnit.G)
+    val expected = Nutrient("carbohydrates", 100.0, MeasurementUnit.G)
     val meal = Meal.default().apply { nutritionalInformation.update(expected) }
     val post =
         Post("userId", "description", Location(0.0, 0.0, 10.0, "EPFL"), meal, LocalDate.now())


### PR DESCRIPTION
These are the helper components for UI of making a new post for others to see. (see #158 for final look of screen.)

Components:
- Picture selector for picking a picture for the post (only a place holder now as we do not yet know if backend will be able to support image for posts)
- Textfield for post description input
- Meal selector for picking a meal for the post
- Meal Details for displaying details of the meal selected for the post
- Alert Dialog for asking for use permission to use their location