### PR TITLE
APK compillation error caused by not enought memory 

### DIFF
--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'release/**'
       - 'main'
+      - 'bugfix/apk-not-enough-ram'
 
 
 jobs:

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'release/**'
       - 'main'
-      - 'bugfix/apk-not-enough-ram'
+      - 'bugfix/apk-not-enought-ram'
 
 
 jobs:

--- a/.github/workflows/apkPipeline.yml
+++ b/.github/workflows/apkPipeline.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'release/**'
       - 'main'
-      - 'bugfix/apk-not-enought-ram'
-
 
 jobs:
   build:

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,8 @@
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 # org.gradle.parallel=true
-#Wed May 01 09:34:46 CEST 2024
+#Fri May 03 09:40:21 CEST 2024
 RELEASE_STORE_FILE=./keystore.jks
 android.useAndroidX=true
 org.gradle.configuration-cache=true
-org.gradle.jvmargs=-Xmx1024M -Dkotlin.daemon.jvm.options\="-Xmx1024M"
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"


### PR DESCRIPTION
Really simple fix consisting of modifying the `gradle.properties` to increase the max memory usage. 