### PR TITLE
Remove NutritionalInformation from Meal constructor

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/data/local/database/MealDatabaseTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/data/local/database/MealDatabaseTest.kt
@@ -111,14 +111,6 @@ class MealDatabaseTest {
             occasion = MealOccasion.BREAKFAST,
             mealID = 1,
             mealTemp = 20.0,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(
-                        Nutrient("calories", 100.0, MeasurementUnit.UG),
-                        Nutrient("protein", 10.0, MeasurementUnit.G),
-                        Nutrient("carbs", 20.0, MeasurementUnit.G),
-                        Nutrient("fat", 5.0, MeasurementUnit.ML)),
-                ),
             ingredients = ingredientList,
             firebaseId = "1",
             createdAt = LocalDate.now())
@@ -179,16 +171,19 @@ class MealDatabaseTest {
         occasion = MealOccasion.BREAKFAST,
         mealID = 1,
         mealTemp = 20.0,
-        nutritionalInformation =
-            NutritionalInformation(
-                mutableListOf(
-                    Nutrient("calories", 100.0, MeasurementUnit.UG),
-                    Nutrient("protein", 10.0, MeasurementUnit.G),
-                    Nutrient("carbs", 20.0, MeasurementUnit.G),
-                    Nutrient("fat", 5.0, MeasurementUnit.ML))),
         ingredients =
             mutableListOf(
-                Ingredient("Oats", 12, 192.2, MeasurementUnit.G),
+                Ingredient(
+                    "Oats",
+                    12,
+                    192.2,
+                    MeasurementUnit.G,
+                    NutritionalInformation(
+                        mutableListOf(
+                            Nutrient("calories", 100.0, MeasurementUnit.UG),
+                            Nutrient("protein", 10.0, MeasurementUnit.G),
+                            Nutrient("carbs", 20.0, MeasurementUnit.G),
+                            Nutrient("fat", 5.0, MeasurementUnit.ML)))),
                 Ingredient("Milk", 200, 12.0, MeasurementUnit.ML)),
         firebaseId = firebaseId,
         createdAt = createdAt)

--- a/app/src/androidTest/java/com/github/se/polyfit/data/remote/firebase/MealFirebaseRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/data/remote/firebase/MealFirebaseRepositoryTest.kt
@@ -2,7 +2,6 @@ package com.github.se.polyfit.data.remote.firebase
 
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
-import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
@@ -51,7 +50,6 @@ class MealFirebaseRepositoryTest {
             name = "Test Meal",
             occasion = MealOccasion.BREAKFAST,
             mealTemp = 20.0,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients = mutableListOf(),
             firebaseId = "1")
     mealNoId =
@@ -60,7 +58,6 @@ class MealFirebaseRepositoryTest {
             name = "Test Meal",
             occasion = MealOccasion.BREAKFAST,
             mealTemp = 20.0,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients = mutableListOf(),
             firebaseId = "")
   }

--- a/app/src/androidTest/java/com/github/se/polyfit/data/repository/MealRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/data/repository/MealRepositoryTest.kt
@@ -5,7 +5,6 @@ import com.github.se.polyfit.data.remote.firebase.MealFirebaseRepository
 import com.github.se.polyfit.data.repository.MealRepository
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
-import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.DocumentReference
 import io.mockk.coEvery
@@ -43,14 +42,7 @@ class MealRepositoryTest {
   @Test
   fun storeMeal_whenConnectionAvailableAndDataNotOutdated_storesMealInFirebaseAndLocalDb() =
       runTest {
-        val meal =
-            Meal(
-                MealOccasion.DINNER,
-                "name",
-                1,
-                12.0,
-                NutritionalInformation(mutableListOf()),
-                mutableListOf())
+        val meal = Meal(MealOccasion.DINNER, "name", 1, 12.0, mutableListOf())
         val documentReference = mockk<DocumentReference>()
         coEvery { mealFirebaseRepository.storeMeal(meal) } returns
             Tasks.forResult(documentReference)
@@ -64,14 +56,7 @@ class MealRepositoryTest {
 
   @Test
   fun storeMeal_whenConnectionNotAvailable_storesMealInLocalDbOnly() = runTest {
-    val meal =
-        Meal(
-            MealOccasion.DINNER,
-            "name",
-            1,
-            12.0,
-            NutritionalInformation(mutableListOf()),
-            mutableListOf())
+    val meal = Meal(MealOccasion.DINNER, "name", 1, 12.0, mutableListOf())
     coEvery { mealDao.insert(any<Meal>()) } returns 109
     coEvery { checkConnectivity.checkConnection() } returns false
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/list/MealListTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/list/MealListTest.kt
@@ -74,8 +74,7 @@ class MealListTest : TestCase() {
           mealID = 1,
           ingredients = mutableListOf(ingredient),
           tags = tags,
-          occasion = MealOccasion.BREAKFAST,
-          nutritionalInformation = NutritionalInformation(mutableListOf()))
+          occasion = MealOccasion.BREAKFAST)
 
   private val meal2 =
       Meal(
@@ -83,8 +82,7 @@ class MealListTest : TestCase() {
           mealID = 2,
           ingredients = mutableListOf(ingredient),
           tags = tags,
-          occasion = MealOccasion.BREAKFAST,
-          nutritionalInformation = NutritionalInformation(mutableListOf()))
+          occasion = MealOccasion.BREAKFAST)
 
   @Test
   fun oneMealDisplays() {

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformationTest.kt
@@ -102,8 +102,7 @@ class NutritionalInformationTest : TestCase() {
           name = "Steak & Veggie",
           ingredients = mutableListOf(ingredient),
           occasion = MealOccasion.DINNER,
-          mealID = 20,
-          nutritionalInformation = NutritionalInformation(mutableListOf()))
+          mealID = 20)
 
   private fun setup(meal: Meal) {
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
@@ -56,7 +56,7 @@ class MealSelectorTest : TestCase() {
 
   @Test
   fun selectingMealReplacesSelector() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",
@@ -90,7 +90,7 @@ class MealSelectorTest : TestCase() {
 
   @Test
   fun selectedMealIsDisplayed() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldTest.kt
@@ -62,7 +62,7 @@ class MealInputTextFieldTest : TestCase() {
 
   @Test
   fun mealsDisplayWhenSearched() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreatePostTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreatePostTest.kt
@@ -86,7 +86,7 @@ class CreatePostTest : TestCase() {
 
   @Test
   fun selectingMealEnablesPostButton() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/DailyRecapTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/DailyRecapTest.kt
@@ -65,8 +65,7 @@ class DailyRecapTest : TestCase() {
                                     MealTag("And yet another long", MealTagColor.LAVENDER),
                                     MealTag(
                                         "And yet another long long", MealTagColor.BRIGHTORANGE)),
-                            occasion = MealOccasion.BREAKFAST,
-                            nutritionalInformation = NutritionalInformation(mutableListOf())),
+                            occasion = MealOccasion.BREAKFAST),
                     ),
                 LocalDate.now().minusDays(1) to
                     listOf(
@@ -91,8 +90,7 @@ class DailyRecapTest : TestCase() {
                                     MealTag("And yet another long", MealTagColor.LAVENDER),
                                     MealTag(
                                         "And yet another long long", MealTagColor.BRIGHTORANGE)),
-                            occasion = MealOccasion.BREAKFAST,
-                            nutritionalInformation = NutritionalInformation(mutableListOf())),
+                            occasion = MealOccasion.BREAKFAST),
                     ))
 
         every { getMealsOnDate(any()) } answers

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
@@ -66,9 +66,7 @@ class IngredientTest : TestCase() {
             occasion = MealOccasion.OTHER,
             name = "Test Meal",
             mealID = 0,
-            ingredients = testIngredients,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
-        )
+            ingredients = testIngredients)
 
     mockMealViewModel.setMealData(testMeal)
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
@@ -64,10 +64,7 @@ class NutritionalInfoTest : TestCase() {
                       100.0,
                       MeasurementUnit.G,
                       NutritionalInformation(
-                          mutableListOf(Nutrient("Calories", 1000.0, MeasurementUnit.CAL))))),
-          nutritionalInformation =
-              NutritionalInformation(
-                  mutableListOf(Nutrient("Calories", 1000.0, MeasurementUnit.CAL))),
+                          mutableListOf(Nutrient("Calories", 2000.0, MeasurementUnit.CAL))))),
           occasion = MealOccasion.LUNCH)
 
   @Before

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/MealViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/MealViewModelTest.kt
@@ -41,12 +41,7 @@ class MealViewModelTest {
     val mealDao = mockk<MealDao>()
     val mealFirebaseRepository = mockk<MealFirebaseRepository>()
 
-    val meal =
-        Meal(
-            occasion = MealOccasion.OTHER,
-            name = "Test Meal",
-            mealID = 1,
-            nutritionalInformation = NutritionalInformation(mutableListOf()))
+    val meal = Meal(occasion = MealOccasion.OTHER, name = "Test Meal", mealID = 1)
 
     every { mealDao.getMealByFirebaseID(any()) } returns meal
     coEvery { mealRepo.getMealByFirebaseID(any()) } returns meal
@@ -115,12 +110,7 @@ class MealViewModelTest {
 
   @Test
   fun testSetMealWithIncompleteMealFails() {
-    val incompleteMeal =
-        Meal(
-            name = "Meal Name",
-            mealID = 123,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
-            occasion = MealOccasion.BREAKFAST)
+    val incompleteMeal = Meal(name = "Meal Name", mealID = 123, occasion = MealOccasion.BREAKFAST)
     viewModel.setMealData(incompleteMeal)
     assertFailsWith<Exception> { viewModel.setMeal() }
   }
@@ -131,13 +121,6 @@ class MealViewModelTest {
         Meal(
             name = "Meal Name",
             mealID = 123,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(
-                        Nutrient(
-                            nutrientType = "calories",
-                            amount = 100.0,
-                            unit = MeasurementUnit.CAL))),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -147,7 +130,7 @@ class MealViewModelTest {
                         unit = MeasurementUnit.G,
                         nutritionalInformation =
                             NutritionalInformation(
-                                mutableListOf(Nutrient("calories", 0.0, MeasurementUnit.CAL))))),
+                                mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.CAL))))),
             occasion = MealOccasion.BREAKFAST)
     runBlockingTest { coEvery { mealRepo.storeMeal(any()) } returns null }
     viewModel.setMealData(completeMeal)
@@ -162,7 +145,6 @@ class MealViewModelTest {
         Meal(
             name = "Meal Name",
             mealID = 123,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -190,12 +172,6 @@ class MealViewModelTest {
             name = "Test Meal",
             occasion = MealOccasion.OTHER,
             mealTemp = 0.0,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(
-                        Nutrient("calories", 0.0, MeasurementUnit.CAL),
-                        Nutrient("totalWeight", 0.0, MeasurementUnit.G),
-                    )),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -203,6 +179,12 @@ class MealViewModelTest {
                         id = 1,
                         amount = 100.0,
                         unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(
+                                    Nutrient("calories", 0.0, MeasurementUnit.CAL),
+                                    Nutrient("totalWeight", 0.0, MeasurementUnit.G),
+                                )),
                     )))
 
     coEvery { mealRepo.getMealById(any()) } returns expectedMeal

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/dailyRecap/DailyRecapViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/dailyRecap/DailyRecapViewModelTest.kt
@@ -55,7 +55,6 @@ class DailyRecapViewModelTest {
                   MealTag("And yet another long", MealTagColor.LAVENDER),
                   MealTag("And yet another long long", MealTagColor.BRIGHTORANGE)),
           occasion = MealOccasion.BREAKFAST,
-          nutritionalInformation = NutritionalInformation(mutableListOf()),
           createdAt = date)
 
   @Test

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/post/CreatePostViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/post/CreatePostViewModelTest.kt
@@ -2,6 +2,7 @@ package com.github.se.polyfit.viewmodel.post
 
 import com.github.se.polyfit.data.remote.firebase.PostFirebaseRepository
 import com.github.se.polyfit.data.repository.MealRepository
+import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
 import com.github.se.polyfit.model.nutritionalInformation.Nutrient
@@ -85,8 +86,11 @@ class CreatePostViewModelTest {
   @Test
   fun getCarbsReturnsCarbsAmount() {
     val carbs = Nutrient("carbohydrates", 10.0, MeasurementUnit.G)
-    val meal =
-        Meal.default().copy(nutritionalInformation = NutritionalInformation(mutableListOf(carbs)))
+    val meal = Meal.default()
+    meal.addIngredient(
+        Ingredient.default()
+            .copy(nutritionalInformation = NutritionalInformation(mutableListOf(carbs))))
+
     val post = Post.default().copy(meal = meal)
     viewModel.setPostData(meal = meal)
 
@@ -98,8 +102,10 @@ class CreatePostViewModelTest {
   @Test
   fun getFatReturnsFatAmount() {
     val fat = Nutrient("fat", 10.0, MeasurementUnit.G)
-    val meal =
-        Meal.default().copy(nutritionalInformation = NutritionalInformation(mutableListOf(fat)))
+    val meal = Meal.default()
+    meal.addIngredient(
+        Ingredient.default()
+            .copy(nutritionalInformation = NutritionalInformation(mutableListOf(fat))))
     val post = Post.default().copy(meal = meal)
     viewModel.setPostData(meal = meal)
 
@@ -109,10 +115,13 @@ class CreatePostViewModelTest {
   }
 
   @Test
-  fun getPoteinReturnsProteinAmount() {
+  fun getProteinReturnsProteinAmount() {
     val protein = Nutrient("protein", 10.0, MeasurementUnit.G)
-    val meal =
-        Meal.default().copy(nutritionalInformation = NutritionalInformation(mutableListOf(protein)))
+    val meal = Meal.default()
+    meal.addIngredient(
+        Ingredient.default()
+            .copy(nutritionalInformation = NutritionalInformation(mutableListOf(protein))))
+
     viewModel.setPostData(meal = meal)
 
     val result = viewModel.getProtein()

--- a/app/src/main/java/com/github/se/polyfit/data/api/SpoonacularAPI.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/api/SpoonacularAPI.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import com.github.se.polyfit.BuildConfig
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
-import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -130,7 +129,6 @@ class SpoonacularApiCaller {
                   apiResponse.category,
                   apiResponse.recipes.first().toLong(),
                   20.0,
-                  NutritionalInformation(recipeInformation.nutrients.toMutableList()),
                   recipeInformation.ingredients.toMutableList(),
                   // firebase id not defined yet because no calls to store the information
                   "")

--- a/app/src/main/java/com/github/se/polyfit/data/local/entity/MealEntity.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/local/entity/MealEntity.kt
@@ -24,16 +24,7 @@ data class MealEntity(
 ) {
 
   fun toMeal(): Meal {
-    return Meal(
-        occasion,
-        name,
-        mealID,
-        mealTemp,
-        nutritionalInformation,
-        ingredients,
-        firebaseId,
-        createdAt,
-        tags)
+    return Meal(occasion, name, mealID, mealTemp, ingredients, firebaseId, createdAt, tags)
   }
 
   companion object {

--- a/app/src/main/java/com/github/se/polyfit/model/ingredient/Ingredient.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/ingredient/Ingredient.kt
@@ -17,7 +17,7 @@ data class Ingredient(
     val id: Long,
     val amount: Double,
     val unit: MeasurementUnit,
-    val nutritionalInformation: NutritionalInformation = NutritionalInformation(mutableListOf()),
+    val nutritionalInformation: NutritionalInformation = NutritionalInformation(),
 ) {
 
   fun deepCopy(): Ingredient {

--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -20,12 +20,35 @@ data class Meal(
     val tags: MutableList<MealTag> = mutableListOf()
 ) {
   var nutritionalInformation: NutritionalInformation = NutritionalInformation()
-    internal set
 
   init {
     require(mealID >= 0)
 
     updateMeal()
+  }
+
+  fun deepCopy(
+      occasion: MealOccasion = this.occasion,
+      name: String = this.name,
+      mealID: Long = this.mealID,
+      mealTemp: Double = this.mealTemp,
+      ingredients: MutableList<Ingredient> = this.ingredients,
+      firebaseId: String = this.firebaseId,
+      createdAt: LocalDate = this.createdAt,
+      tags: MutableList<MealTag> = this.tags
+  ): Meal {
+    val newIngredients = ingredients.map { it.deepCopy() }.toMutableList()
+    val newTags = tags.map { it.copy() }.toMutableList()
+
+    return Meal(
+        occasion = occasion,
+        name = name,
+        mealID = mealID,
+        mealTemp = mealTemp,
+        ingredients = newIngredients,
+        firebaseId = firebaseId,
+        createdAt = createdAt,
+        tags = newTags)
   }
 
   override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -115,6 +115,7 @@ data class Meal(
         this["occasion"] = data.occasion.name
         this["name"] = data.name
         this["mealTemp"] = data.mealTemp
+        this["nutritionalInformation"] = listOf<Any>() // TODO: Remove after M2 Grading
         this["ingredients"] = data.ingredients.map { Ingredient.serialize(it) }
         this["createdAt"] = data.createdAt.toString()
         this["tags"] = data.tags.map { MealTag.serialize(it) }

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformation.kt
@@ -2,10 +2,10 @@ package com.github.se.polyfit.model.nutritionalInformation
 
 import android.util.Log
 
-class NutritionalInformation {
+class NutritionalInformation(nutrientsList: MutableList<Nutrient> = mutableListOf()) {
   val nutrients: MutableList<Nutrient> = mutableListOf()
 
-  constructor(nutrientsList: MutableList<Nutrient>) {
+  init {
     nutrients.addAll(nutrientsList.map { it.deepCopy() })
   }
 
@@ -17,7 +17,7 @@ class NutritionalInformation {
   }
 
   fun deepCopy(): NutritionalInformation {
-    val newNutritionalInformation = NutritionalInformation(mutableListOf())
+    val newNutritionalInformation = NutritionalInformation()
     nutrients.forEach { newNutritionalInformation.update(it.copy()) }
     return newNutritionalInformation
   }
@@ -73,7 +73,7 @@ class NutritionalInformation {
   }
 
   operator fun plus(other: NutritionalInformation): NutritionalInformation {
-    val newNutritionalInformation = NutritionalInformation(mutableListOf())
+    val newNutritionalInformation = NutritionalInformation()
 
     nutrients.forEach { newNutritionalInformation.update(it) }
     other.nutrients.forEach { newNutritionalInformation.update(it) }
@@ -82,7 +82,7 @@ class NutritionalInformation {
   }
 
   operator fun minus(other: NutritionalInformation): NutritionalInformation {
-    val newNutritionalInformation = NutritionalInformation(mutableListOf())
+    val newNutritionalInformation = NutritionalInformation()
 
     nutrients.forEach { newNutritionalInformation.update(it) }
     other.nutrients.forEach { newNutritionalInformation.update(it * -1.0) }
@@ -100,7 +100,7 @@ class NutritionalInformation {
     }
 
     fun deserialize(data: List<Map<String, Any>>): NutritionalInformation {
-      val nutritionalInformation = NutritionalInformation(mutableListOf())
+      val nutritionalInformation = NutritionalInformation()
       data.forEach {
         try {
 

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -8,7 +8,6 @@ import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
 import com.github.se.polyfit.model.meal.MealTag
-import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.LocalDate
 import javax.inject.Inject
@@ -62,28 +61,16 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
       createdAt: LocalDate = _meal.value.createdAt,
       tags: MutableList<MealTag> = _meal.value.tags
   ) {
-    // When we make a new Meal, we add all the ingredient values into nutritionalInfo. If we pass
-    // existing values, then its double adding
-    val newNutritionalInformation = NutritionalInformation(mutableListOf())
     _meal.value =
-        Meal(
-            mealOccasion,
-            name,
-            mealID,
-            mealTemp,
-            newNutritionalInformation,
-            ingredients,
-            firebaseID,
-            createdAt,
-            tags)
+        Meal(mealOccasion, name, mealID, mealTemp, ingredients, firebaseID, createdAt, tags)
   }
 
   fun setMealCreatedAt(createdAt: LocalDate) {
-    _meal.value = _meal.value.deepCopy(createdAt = createdAt)
+    _meal.value = _meal.value.copy(createdAt = createdAt)
   }
 
   fun setMealOccasion(occasion: MealOccasion) {
-    _meal.value = _meal.value.deepCopy(occasion = occasion)
+    _meal.value = _meal.value.copy(occasion = occasion)
   }
 
   fun setMeal() {
@@ -102,13 +89,13 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
 
   fun addIngredient(ingredient: Ingredient) {
     val updatedIngredients = _meal.value.ingredients.toMutableList().apply { add(ingredient) }
-    _meal.value = _meal.value.deepCopy(ingredients = updatedIngredients)
+    _meal.value = _meal.value.copy(ingredients = updatedIngredients)
   }
 
   fun removeIngredient(ingredient: Ingredient) {
     val updatedIngredients = _meal.value.ingredients.toMutableList().apply { remove(ingredient) }
 
-    _meal.value = _meal.value.deepCopy(ingredients = updatedIngredients)
+    _meal.value = _meal.value.copy(ingredients = updatedIngredients)
   }
 
   fun addTag(tag: MealTag) {

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -66,11 +66,11 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
   }
 
   fun setMealCreatedAt(createdAt: LocalDate) {
-    _meal.value = _meal.value.copy(createdAt = createdAt)
+    _meal.value = _meal.value.deepCopy(createdAt = createdAt)
   }
 
   fun setMealOccasion(occasion: MealOccasion) {
-    _meal.value = _meal.value.copy(occasion = occasion)
+    _meal.value = _meal.value.deepCopy(occasion = occasion)
   }
 
   fun setMeal() {
@@ -89,13 +89,13 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
 
   fun addIngredient(ingredient: Ingredient) {
     val updatedIngredients = _meal.value.ingredients.toMutableList().apply { add(ingredient) }
-    _meal.value = _meal.value.copy(ingredients = updatedIngredients)
+    _meal.value = _meal.value.deepCopy(ingredients = updatedIngredients)
   }
 
   fun removeIngredient(ingredient: Ingredient) {
     val updatedIngredients = _meal.value.ingredients.toMutableList().apply { remove(ingredient) }
 
-    _meal.value = _meal.value.copy(ingredients = updatedIngredients)
+    _meal.value = _meal.value.deepCopy(ingredients = updatedIngredients)
   }
 
   fun addTag(tag: MealTag) {

--- a/app/src/test/java/com/github/se/polyfit/data/processor/LocalDataProcessorTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/data/processor/LocalDataProcessorTest.kt
@@ -95,14 +95,19 @@ class LocalDataProcessorTest {
           name = name,
           mealID = 1,
           mealTemp = 20.0,
-          nutritionalInformation =
-              NutritionalInformation(
-                  mutableListOf(
-                      Nutrient("calories", calories, MeasurementUnit.UG),
-                      Nutrient("protein", 10.0, MeasurementUnit.G),
-                      Nutrient("carbs", 20.0, MeasurementUnit.G),
-                      Nutrient("fat", 5.0, MeasurementUnit.ML))),
-          ingredients = mutableListOf(Ingredient(name, 100, 10.0, MeasurementUnit.G)),
+          ingredients =
+              mutableListOf(
+                  Ingredient(
+                      name,
+                      100,
+                      10.0,
+                      MeasurementUnit.G,
+                      NutritionalInformation(
+                          mutableListOf(
+                              Nutrient("calories", calories, MeasurementUnit.UG),
+                              Nutrient("protein", 10.0, MeasurementUnit.G),
+                              Nutrient("carbs", 20.0, MeasurementUnit.G),
+                              Nutrient("fat", 5.0, MeasurementUnit.ML))))),
           firebaseId = "1",
           createdAt = LocalDate.now())
 

--- a/app/src/test/java/com/github/se/polyfit/model/ingredient/IngredientTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/ingredient/IngredientTest.kt
@@ -12,8 +12,7 @@ import org.junit.Before
 import org.junit.Test
 
 class IngredientTest {
-  private val ingredient =
-      Ingredient("eggs", 1, 1.2, MeasurementUnit.G, NutritionalInformation(mutableListOf()))
+  private val ingredient = Ingredient("eggs", 1, 1.2, MeasurementUnit.G, NutritionalInformation())
 
   @Before
   fun setup() {
@@ -68,7 +67,7 @@ class IngredientTest {
   @Test
   fun testSerializationDeserializationWithDefaultValues() {
     val ingredientWithDefaultValues =
-        Ingredient("eggs", 1, 1.2, MeasurementUnit.G, NutritionalInformation(mutableListOf()))
+        Ingredient("eggs", 1, 1.2, MeasurementUnit.G, NutritionalInformation())
     // Serialize the Ingredient object
     val serializedIngredient = Ingredient.serialize(ingredientWithDefaultValues)
     // Deserialize the serialized Ingredient object

--- a/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
@@ -24,17 +24,14 @@ class MealTest {
 
   @Test
   fun `Meal addIngredient should update meal`() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2, NutritionalInformation(mutableListOf()))
+    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
     val newNutritionalInformation =
         NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G)))
 
     val ingredient = Ingredient("milk", 1, 102.0, MeasurementUnit.MG, newNutritionalInformation)
     meal.addIngredient(ingredient)
-    // Assert that the meal has been updated after adding an ingredient
     assertEquals(1, meal.ingredients.size)
-    // Assert that the meal's nutritional information has been updated
-
-    assertEquals(1.0, meal.nutritionalInformation.nutrients[0].amount, 0.001)
+    assertEquals(1.0, meal.getNutrient("calcium")!!.amount, 0.001)
   }
 
   @Test
@@ -45,7 +42,6 @@ class MealTest {
             "eggs",
             1.toLong(),
             102.2,
-            NutritionalInformation(mutableListOf()),
             createdAt = LocalDate.parse("2021-01-01"),
             tags = mutableListOf(MealTag("name of tag", MealTagColor.BLUE)))
     val serializedMeal = Meal.serialize(meal)
@@ -67,7 +63,6 @@ class MealTest {
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to "wrongValue",
-            "nutritionalInformation" to listOf<Map<String, Any>>(),
             "createdAt" to "notARealDate")
     // Make sure that an exception is thrown
     assertFailsWith<Exception> { Meal.deserialize(data) }
@@ -81,7 +76,6 @@ class MealTest {
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to 102.2,
-            "nutritionalInformation" to NutritionalInformation(mutableListOf()).serialize(),
             "createdAt" to "2021-01-01",
             "tags" to mutableListOf(MealTag("name of tag", MealTagColor.BLUE).serialize()))
     val meal = Meal.deserialize(data)
@@ -103,7 +97,6 @@ class MealTest {
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to 102.2,
-            "nutritionalInformation" to listOf<Map<String, Any>>(),
             "createdAt" to "2021-01-01",
             "tags" to listOf<Map<String, Any>>())
 
@@ -120,16 +113,7 @@ class MealTest {
             name = "",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation =
-                NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G))),
-            ingredients =
-                mutableListOf(
-                    Ingredient(
-                        "milk",
-                        1,
-                        102.0,
-                        MeasurementUnit.MG,
-                        NutritionalInformation(mutableListOf()))))
+            ingredients = mutableListOf(Ingredient("milk", 1, 102.0, MeasurementUnit.MG)))
 
     assertEquals(false, meal.isComplete())
   }
@@ -142,8 +126,6 @@ class MealTest {
             name = "eggs",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation =
-                NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G))),
             ingredients = mutableListOf())
 
     assertEquals(false, meal.isComplete())
@@ -157,15 +139,7 @@ class MealTest {
             name = "eggs",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
-            ingredients =
-                mutableListOf(
-                    Ingredient(
-                        "milk",
-                        1,
-                        102.0,
-                        MeasurementUnit.MG,
-                        NutritionalInformation(mutableListOf()))))
+            ingredients = mutableListOf(Ingredient("milk", 1, 102.0, MeasurementUnit.MG)))
 
     assertEquals(false, meal.isComplete())
   }
@@ -178,8 +152,6 @@ class MealTest {
             name = "eggs",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation =
-                NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G))),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -187,7 +159,8 @@ class MealTest {
                         1,
                         102.0,
                         MeasurementUnit.MG,
-                        NutritionalInformation(mutableListOf()))))
+                        NutritionalInformation(
+                            mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G))))))
 
     assertEquals(true, meal.isComplete())
   }
@@ -200,7 +173,6 @@ class MealTest {
             name = "eggs",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients =
                 mutableListOf(
                     Ingredient(
@@ -224,7 +196,6 @@ class MealTest {
             name = "eggs",
             mealID = 1,
             mealTemp = 102.2,
-            nutritionalInformation = NutritionalInformation(mutableListOf()),
             ingredients =
                 mutableListOf(
                     Ingredient(

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/NutritionalInformationTest.kt
@@ -205,7 +205,7 @@ class NutritionalInformationTest {
 
   @Test
   fun `update shouldn't add a nutrient if the amount is less than 0`() {
-    val nutritionalInformation1 = NutritionalInformation(mutableListOf())
+    val nutritionalInformation1 = NutritionalInformation()
     val nutritionalInformation2 =
         NutritionalInformation(mutableListOf(Nutrient("Total Weight", -10.0, MeasurementUnit.G)))
 

--- a/app/src/test/java/com/github/se/polyfit/viewmodel/meal/OverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/viewmodel/meal/OverviewViewModelTest.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.util.Log
 import com.github.se.polyfit.data.api.SpoonacularApiCaller
 import com.github.se.polyfit.data.local.dao.MealDao
+import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
 import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
@@ -66,28 +67,50 @@ class OverviewViewModelTest {
     val meal1 =
         Meal(
             mealID = 1,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))),
             name = "Meal 1",
-            occasion = MealOccasion.BREAKFAST)
+            occasion = MealOccasion.BREAKFAST,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
             mealID = 2,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 200.0, MeasurementUnit.KCAL))),
             name = "Meal 2",
-            occasion = MealOccasion.LUNCH)
+            occasion = MealOccasion.LUNCH,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 200.0, MeasurementUnit.KCAL))))))
 
     val meal3 =
         Meal(
             mealID = 3,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 300.0, MeasurementUnit.KCAL))),
             name = "Meal 3",
-            occasion = MealOccasion.DINNER)
+            occasion = MealOccasion.DINNER,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 300.0, MeasurementUnit.KCAL))))))
+
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -135,30 +158,9 @@ class OverviewViewModelTest {
   @Test
   fun getMealsByOccasion_returnsCorrectMeals() {
     // Prepare the meals
-    val meal1 =
-        Meal(
-            mealID = 1,
-            name = "Breakfast Meal",
-            occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))
-    val meal2 =
-        Meal(
-            mealID = 2,
-            name = "Lunch Meal",
-            occasion = MealOccasion.LUNCH,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))
-    val meal3 =
-        Meal(
-            mealID = 3,
-            name = "Dinner Meal",
-            occasion = MealOccasion.DINNER,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))
+    val meal1 = Meal(mealID = 1, name = "Breakfast Meal", occasion = MealOccasion.BREAKFAST)
+    val meal2 = Meal(mealID = 2, name = "Lunch Meal", occasion = MealOccasion.LUNCH)
+    val meal3 = Meal(mealID = 3, name = "Dinner Meal", occasion = MealOccasion.DINNER)
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -175,30 +177,9 @@ class OverviewViewModelTest {
   @Test
   fun getMealsByOccasion_noMatchingMeals() {
     // Prepare the meals
-    val meal1 =
-        Meal(
-            mealID = 1,
-            name = "Breakfast Meal",
-            occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))
-    val meal2 =
-        Meal(
-            mealID = 2,
-            name = "Lunch Meal",
-            occasion = MealOccasion.LUNCH,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))
-    val meal3 =
-        Meal(
-            mealID = 3,
-            name = "Dinner Meal",
-            occasion = MealOccasion.DINNER,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))
+    val meal1 = Meal(mealID = 1, name = "Breakfast Meal", occasion = MealOccasion.BREAKFAST)
+    val meal2 = Meal(mealID = 2, name = "Lunch Meal", occasion = MealOccasion.LUNCH)
+    val meal3 = Meal(mealID = 3, name = "Dinner Meal", occasion = MealOccasion.DINNER)
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -219,25 +200,47 @@ class OverviewViewModelTest {
             mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
             mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
             mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))))
+
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -261,25 +264,47 @@ class OverviewViewModelTest {
             mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
             mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
             mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))))
+
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -299,27 +324,49 @@ class OverviewViewModelTest {
     val meal1 =
         Meal(
             mealID = 1,
-            occasion = MealOccasion.BREAKFAST,
             name = "Chicken Salad",
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))
+            occasion = MealOccasion.BREAKFAST,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
             mealID = 2,
             name = "Beef Stew",
-            occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))
+            occasion = MealOccasion.LUNCH,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
             mealID = 3,
             name = "Chicken Soup",
-            occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))
+            occasion = MealOccasion.DINNER,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))))
+
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -351,25 +398,47 @@ class OverviewViewModelTest {
             mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
             mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
             mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 350.0, MeasurementUnit.KCAL))))))
+
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -389,27 +458,48 @@ class OverviewViewModelTest {
     val meal1 =
         Meal(
             mealID = 1,
-            occasion = MealOccasion.BREAKFAST,
             name = "Chicken Salad",
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))
+            occasion = MealOccasion.BREAKFAST,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
             mealID = 2,
-            occasion = MealOccasion.BREAKFAST,
             name = "Beef Stew",
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))
+            occasion = MealOccasion.LUNCH,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
             mealID = 3,
             name = "Chicken Soup",
-            occasion = MealOccasion.BREAKFAST,
-            nutritionalInformation =
-                NutritionalInformation(
-                    mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))
+            occasion = MealOccasion.DINNER,
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))))
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -442,8 +532,16 @@ class OverviewViewModelTest {
             mealID = 1,
             occasion = MealOccasion.BREAKFAST,
             name = "Chicken Salad",
-            nutritionalInformation =
-                NutritionalInformation(mutableListOf(Nutrient("fat", 150.0, MeasurementUnit.G))))
+            ingredients =
+                mutableListOf(
+                    Ingredient(
+                        name = "ingredient1",
+                        id = 0,
+                        amount = 10.0,
+                        unit = MeasurementUnit.G,
+                        nutritionalInformation =
+                            NutritionalInformation(
+                                mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))))
 
     val allMeals = listOf(meal1)
 


### PR DESCRIPTION
This PR is the first pass of this task - `NutritionalInformation` is removed from the `Meal` constructor parameters and calculated during construction from the ingredients. As a safeguard, it is accessible publicly but only able to be set internally. We can remove the `deepCopy` function as regular copying should now properly calculate nutrition.

The second pass after the cleanup (not required, but could be a good idea) is to run a database migration to drop the `nutritionalInformation` column. I will do this in a following PR since it will be easier to do once the cleanup is finished.

A lot of this code is deleting `NutritionalInformation` from `Meal` constructors in tests and moving it into ingredients (if needed for that test) so that the functionality of all the tests is preserved.

For ease of future use, the `NutritionalInformation` class now defaults to having an empty list of `Nutrient`, since it was often used across the code base explicitly (`NutritionalInformation(mutableListOf())`)