### PR TITLE
Updated Meal id's

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,12 @@ android {
         versionCode = 1
         versionName = "1.0"
 
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments["room.schemaLocation"] = "$projectDir/schemas"
+            }
+        }
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true

--- a/app/schemas/com.github.se.polyfit.data.local.database.MealDatabase/1.json
+++ b/app/schemas/com.github.se.polyfit.data.local.database.MealDatabase/1.json
@@ -1,0 +1,88 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "27e2cb642d14fd752f3cde598a37f6ef",
+    "entities": [
+      {
+        "tableName": "MealTable",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occasion` TEXT NOT NULL, `name` TEXT NOT NULL, `mealID` INTEGER NOT NULL, `mealTemp` REAL NOT NULL, `nutritionalInformation` TEXT NOT NULL, `ingredients` TEXT NOT NULL, `firebaseId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `tags` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occasion",
+            "columnName": "occasion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealID",
+            "columnName": "mealID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealTemp",
+            "columnName": "mealTemp",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nutritionalInformation",
+            "columnName": "nutritionalInformation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredients",
+            "columnName": "ingredients",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firebaseId",
+            "columnName": "firebaseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '27e2cb642d14fd752f3cde598a37f6ef')"
+    ]
+  }
+}

--- a/app/schemas/com.github.se.polyfit.data.local.database.MealDatabase/2.json
+++ b/app/schemas/com.github.se.polyfit.data.local.database.MealDatabase/2.json
@@ -1,0 +1,82 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "1d225232b0cdfc89a0e25f26ddaf14c5",
+    "entities": [
+      {
+        "tableName": "MealTable",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `occasion` TEXT NOT NULL, `name` TEXT NOT NULL, `mealTemp` REAL NOT NULL, `nutritionalInformation` TEXT NOT NULL, `ingredients` TEXT NOT NULL, `firebaseId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `tags` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occasion",
+            "columnName": "occasion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealTemp",
+            "columnName": "mealTemp",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nutritionalInformation",
+            "columnName": "nutritionalInformation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredients",
+            "columnName": "ingredients",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firebaseId",
+            "columnName": "firebaseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1d225232b0cdfc89a0e25f26ddaf14c5')"
+    ]
+  }
+}

--- a/app/schemas/com.github.se.polyfit.data.local.database.MealDatabase/3.json
+++ b/app/schemas/com.github.se.polyfit.data.local.database.MealDatabase/3.json
@@ -1,0 +1,76 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "ef5c1da7ecd00ee21d0d88ff940793ad",
+    "entities": [
+      {
+        "tableName": "MealTable",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `occasion` TEXT NOT NULL, `name` TEXT NOT NULL, `mealTemp` REAL NOT NULL, `nutritionalInformation` TEXT NOT NULL, `ingredients` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `tags` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occasion",
+            "columnName": "occasion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealTemp",
+            "columnName": "mealTemp",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nutritionalInformation",
+            "columnName": "nutritionalInformation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredients",
+            "columnName": "ingredients",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ef5c1da7ecd00ee21d0d88ff940793ad')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/data/api/SpoonacularApiCallerTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/data/api/SpoonacularApiCallerTest.kt
@@ -217,7 +217,8 @@ class SpoonacularApiCallerTest {
     }
 
     // Assert
-    assertEquals(Meal.default(), actualMeal!!)
+    val expected = Meal.default().deepCopy(id = actualMeal.id)
+    assertEquals(expected, actualMeal)
   }
 
   @Test
@@ -236,7 +237,8 @@ class SpoonacularApiCallerTest {
     }
 
     // Assert
-    assertEquals(Meal.default(), actualMeal!!)
+    val expected = Meal.default().deepCopy(id = actualMeal.id)
+    assertEquals(expected, actualMeal)
   }
 
   @After

--- a/app/src/androidTest/java/com/github/se/polyfit/data/local/database/MealDatabaseTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/data/local/database/MealDatabaseTest.kt
@@ -42,7 +42,7 @@ class MealDatabaseTest {
         MealEntity(
             occasion = MealOccasion.BREAKFAST,
             name = "Oatmeal",
-            mealID = 1,
+            id = "TestId",
             mealTemp = 20.0,
             nutritionalInformation =
                 NutritionalInformation(
@@ -56,7 +56,6 @@ class MealDatabaseTest {
                 mutableListOf(
                     Ingredient("Oats", 12, 192.2, MeasurementUnit.G),
                     Ingredient("Milk", 200, 12.0, MeasurementUnit.ML)),
-            firebaseId = "1",
             createdAt = nowTime,
             tags = mutableListOf()))
 
@@ -76,29 +75,6 @@ class MealDatabaseTest {
   }
 
   @Test
-  fun testOneMealDelete() {
-    mealDao.deleteAll()
-
-    mealDao.insert(Meal.default().apply { firebaseId = "aer1" })
-    mealDao.insert(Meal.default())
-
-    mealDao.deleteByFirebaseID("aer1")
-
-    assertEquals(mealDao.getAllMeals().size, 1)
-  }
-
-  @Test
-  fun getMealByFirebaseID() {
-    mealDao.deleteAll()
-    val meal = Meal.default().apply { firebaseId = "aer1" }
-    mealDao.insert(meal)
-
-    val mealFromDB = mealDao.getMealByFirebaseID("aer1")
-
-    assertEquals(meal, mealFromDB)
-  }
-
-  @Test
   fun getAllIngredients() {
     val ingredientList =
         mutableListOf(
@@ -109,10 +85,9 @@ class MealDatabaseTest {
         Meal(
             name = "Oatmeal",
             occasion = MealOccasion.BREAKFAST,
-            mealID = 1,
+            id = "TestId",
             mealTemp = 20.0,
             ingredients = ingredientList,
-            firebaseId = "1",
             createdAt = LocalDate.now())
     mealDao.insert(MealEntity.toMealEntity(meal))
 
@@ -151,7 +126,7 @@ class MealDatabaseTest {
     mealDao.deleteAll()
     val meal = createMeal("Oatmeal", "1", LocalDate.now())
     val id = mealDao.insert(meal)
-    val mealFromDB = mealDao.getMealByDatabaseID(id)
+    val mealFromDB = mealDao.getMealById(id)
     assertEquals(meal, mealFromDB)
   }
 
@@ -160,16 +135,16 @@ class MealDatabaseTest {
     mealDao.deleteAll()
     val meal = createMeal("Oatmeal", "1", LocalDate.now())
     val id = mealDao.insert(meal)
-    mealDao.deleteByDatabaseID(id)
-    val mealFromDB = mealDao.getMealByDatabaseID(id)
+    mealDao.deleteById(id)
+    val mealFromDB = mealDao.getMealById(id)
     assertEquals(null, mealFromDB)
   }
 
-  private fun createMeal(name: String, firebaseId: String, createdAt: LocalDate): Meal {
+  private fun createMeal(name: String, id: String, createdAt: LocalDate): Meal {
     return Meal(
         name = name,
         occasion = MealOccasion.BREAKFAST,
-        mealID = 1,
+        id = id,
         mealTemp = 20.0,
         ingredients =
             mutableListOf(
@@ -185,7 +160,6 @@ class MealDatabaseTest {
                             Nutrient("carbs", 20.0, MeasurementUnit.G),
                             Nutrient("fat", 5.0, MeasurementUnit.ML)))),
                 Ingredient("Milk", 200, 12.0, MeasurementUnit.ML)),
-        firebaseId = firebaseId,
         createdAt = createdAt)
   }
 

--- a/app/src/androidTest/java/com/github/se/polyfit/data/repository/MealRepositoryTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/data/repository/MealRepositoryTest.kt
@@ -42,11 +42,11 @@ class MealRepositoryTest {
   @Test
   fun storeMeal_whenConnectionAvailableAndDataNotOutdated_storesMealInFirebaseAndLocalDb() =
       runTest {
-        val meal = Meal(MealOccasion.DINNER, "name", 1, 12.0, mutableListOf())
+        val meal = Meal(MealOccasion.DINNER, "name", "1", 12.0, mutableListOf())
         val documentReference = mockk<DocumentReference>()
         coEvery { mealFirebaseRepository.storeMeal(meal) } returns
             Tasks.forResult(documentReference)
-        coEvery { mealDao.insert(any<Meal>()) } returns 109
+        coEvery { mealDao.insert(any<Meal>()) } returns "109"
         coEvery { checkConnectivity.checkConnection() } returns true
 
         val result = mealRepository.storeMeal(meal)
@@ -56,8 +56,8 @@ class MealRepositoryTest {
 
   @Test
   fun storeMeal_whenConnectionNotAvailable_storesMealInLocalDbOnly() = runTest {
-    val meal = Meal(MealOccasion.DINNER, "name", 1, 12.0, mutableListOf())
-    coEvery { mealDao.insert(any<Meal>()) } returns 109
+    val meal = Meal(MealOccasion.DINNER, "name", "1", 12.0, mutableListOf())
+    coEvery { mealDao.insert(any<Meal>()) } returns "109"
     coEvery { checkConnectivity.checkConnection() } returns false
 
     val result = mealRepository.storeMeal(meal)
@@ -67,27 +67,30 @@ class MealRepositoryTest {
 
   @Test
   fun getMeal() = runTest {
-    every { mealDao.getMealByFirebaseID(any()) } returns Meal.default()
+    val default = Meal.default()
+    every { mealDao.getMealById(any()) } returns default
 
-    val result = mealRepository.getMealByFirebaseID("1")
+    val result = mealRepository.getMealById("1")
 
-    assertEquals(Meal.default(), result)
+    assertEquals(default, result)
   }
 
   @Test
   fun getAllMeals() = runTest {
-    every { mealDao.getAllMeals() } returns listOf(Meal.default(), Meal.default())
+    val meal1 = Meal.default()
+    val meal2 = Meal.default()
+    every { mealDao.getAllMeals() } returns listOf(meal1, meal2)
 
     val result = mealRepository.getAllMeals()
 
-    assertEquals(listOf(Meal.default(), Meal.default()), result)
+    assertEquals(listOf(meal1, meal2), result)
   }
 
   @Test
   fun deleteMeal_whenConnectionAvailableAndDataNotOutdated_deletesMealFromFirebaseAndLocalDb() =
       runTest {
         coEvery { mealFirebaseRepository.deleteMeal("1") } returns Tasks.forResult(Unit)
-        coEvery { mealDao.deleteByFirebaseID("1") } returns Unit
+        coEvery { mealDao.deleteById("1") } returns Unit
         coEvery { checkConnectivity.checkConnection() } returns true
 
         mealRepository.deleteMeal("1")
@@ -96,7 +99,7 @@ class MealRepositoryTest {
   @Test
   fun outdateddata() = runTest {
     coEvery { checkConnectivity.checkConnection() } returns false
-    coEvery { mealDao.insert(any<Meal>()) } returns 109
+    coEvery { mealDao.insert(any<Meal>()) } returns "109"
     val docId = mealRepository.storeMeal(Meal.default())
 
     assertEquals(null, docId)
@@ -127,7 +130,7 @@ class MealRepositoryTest {
     val mockDoc = mockk<DocumentReference>()
     coEvery { mealFirebaseRepository.storeMeal(any()) } returns Tasks.forResult(mockDoc)
     coEvery { mealDao.getAllMeals() } returns listOf(Meal.default())
-    coEvery { mealDao.insert(any<Meal>()) } returns 109
+    coEvery { mealDao.insert(any<Meal>()) } returns "109"
 
     mealRepository.storeMeal(Meal.default())
     val result = mealRepository.storeMeal(Meal.default())
@@ -155,8 +158,8 @@ class MealRepositoryTest {
     coEvery { mealFirebaseRepository.deleteMeal(any()) } returns Tasks.forResult(Unit)
     coEvery { mealFirebaseRepository.storeMeal(any()) } returns Tasks.forResult(mockDoc)
     coEvery { mealDao.getAllMeals() } returns listOf(Meal.default())
-    coEvery { mealDao.insert(any<Meal>()) } returns 109
-    coEvery { mealDao.deleteByFirebaseID(any()) } returns Unit
+    coEvery { mealDao.insert(any<Meal>()) } returns "109"
+    coEvery { mealDao.deleteById(any()) } returns Unit
 
     mealRepository.storeMeal(Meal.default())
     val result = mealRepository.storeMeal(Meal.default())
@@ -167,9 +170,10 @@ class MealRepositoryTest {
   }
 
   @Test
-  fun getMealByFirebaseID() = runTest {
-    every { mealDao.getMealByFirebaseID(any()) } returns Meal.default()
-    val result = mealRepository.getMealByFirebaseID("1")
-    assertEquals(Meal.default(), result)
+  fun getMealById() = runTest {
+    val default = Meal.default()
+    every { mealDao.getMealById(any()) } returns default
+    val result = mealRepository.getMealById("1")
+    assertEquals(default, result)
   }
 }

--- a/app/src/androidTest/java/com/github/se/polyfit/end2end/EndTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/end2end/EndTest.kt
@@ -51,6 +51,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import java.util.UUID
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Before
@@ -70,13 +71,14 @@ class EndTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport
       GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
 
   private val overviewViewModel: OverviewViewModel = mockk(relaxed = true)
+  private val id = UUID.randomUUID().toString()
 
   @Before
   fun SettingUp() {
     mockkStatic(Log::class)
     System.setProperty("isTestEnvironment", "true")
 
-    every { overviewViewModel.storeMeal(any()) } returns 1L
+    every { overviewViewModel.storeMeal(any()) } returns id
   }
 
   @After
@@ -118,7 +120,7 @@ class EndTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupport
         }
         composable(Route.CreatePost) { CreatePostScreen(postViewModel = mockPostViewModel) }
         composable(Route.AddMeal + "/{mId}") { backStackEntry ->
-          val mealId = backStackEntry.arguments?.getString("mId")?.toLong()
+          val mealId = backStackEntry.arguments?.getString("mId")
           AddMealFlow({}, {}, mealId = mealId, mealViewModel)
         }
       }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/list/MealListScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/list/MealListScreen.kt
@@ -14,5 +14,4 @@ class MealListScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val mealCard: KNode = onNode { hasTestTag("MealCard") }
   val mealName: KNode = onNode { hasTestTag("MealName") }
   val mealCalories: KNode = onNode { hasTestTag("MealCalories") }
-  val mealTagList: KNode = onNode { hasTestTag("MealTagList") }
 }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/list/MealListTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/list/MealListTest.kt
@@ -1,8 +1,10 @@
 package com.github.se.polyfit.ui.components.list
 
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.meal.Meal
@@ -16,7 +18,6 @@ import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.mockk.junit4.MockKRule
-import io.mockk.mockk
 import kotlin.test.Test
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -31,9 +32,9 @@ class MealListTest : TestCase() {
   fun setContent(
       meals: List<Meal> = emptyList(),
       occasion: MealOccasion = MealOccasion.BREAKFAST,
-      navigateTo: () -> Unit = {}
+      navigateTo: (String?) -> Unit = {}
   ) {
-    composeTestRule.setContent { MealList(meals, occasion, navigateTo, mealViewModel = mockk()) }
+    composeTestRule.setContent { MealList(meals, occasion, navigateTo) }
   }
 
   @Test
@@ -71,7 +72,6 @@ class MealListTest : TestCase() {
   private val meal1 =
       Meal(
           name = "Meal 1",
-          mealID = 1,
           ingredients = mutableListOf(ingredient),
           tags = tags,
           occasion = MealOccasion.BREAKFAST)
@@ -79,7 +79,6 @@ class MealListTest : TestCase() {
   private val meal2 =
       Meal(
           name = "Meal 2",
-          mealID = 2,
           ingredients = mutableListOf(ingredient),
           tags = tags,
           occasion = MealOccasion.BREAKFAST)
@@ -106,7 +105,7 @@ class MealListTest : TestCase() {
         assertTextEquals("10.0")
       }
 
-      mealTagList { assertIsDisplayed() }
+      composeTestRule.onNodeWithTag("MealTagList", true).assertIsDisplayed()
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/nutrition/NutritionalInformationTest.kt
@@ -101,8 +101,7 @@ class NutritionalInformationTest : TestCase() {
       Meal(
           name = "Steak & Veggie",
           ingredients = mutableListOf(ingredient),
-          occasion = MealOccasion.DINNER,
-          mealID = 20)
+          occasion = MealOccasion.DINNER)
 
   private fun setup(meal: Meal) {
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
@@ -56,7 +56,7 @@ class MealSelectorTest : TestCase() {
 
   @Test
   fun selectingMealReplacesSelector() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
+    val meal = Meal(MealOccasion.DINNER, "eggs", "1", 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",
@@ -90,7 +90,7 @@ class MealSelectorTest : TestCase() {
 
   @Test
   fun selectedMealIsDisplayed() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
+    val meal = Meal(MealOccasion.DINNER, "eggs", "1", 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/textField/MealInputTextFieldTest.kt
@@ -62,7 +62,7 @@ class MealInputTextFieldTest : TestCase() {
 
   @Test
   fun mealsDisplayWhenSearched() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
+    val meal = Meal(MealOccasion.DINNER, "eggs", "1", 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreatePostTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreatePostTest.kt
@@ -86,7 +86,7 @@ class CreatePostTest : TestCase() {
 
   @Test
   fun selectingMealEnablesPostButton() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
+    val meal = Meal(MealOccasion.DINNER, "eggs", "1", 102.2)
     meal.addIngredient(
         Ingredient(
             "milk",

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/DailyRecapTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/DailyRecapTest.kt
@@ -45,7 +45,6 @@ class DailyRecapTest : TestCase() {
                 date to
                     listOf(
                         Meal(
-                            mealID = 1,
                             name = "Meal 1",
                             ingredients =
                                 mutableListOf(
@@ -70,7 +69,6 @@ class DailyRecapTest : TestCase() {
                 LocalDate.now().minusDays(1) to
                     listOf(
                         Meal(
-                            mealID = 2,
                             name = "Meal 2",
                             ingredients =
                                 mutableListOf(
@@ -105,12 +103,12 @@ class DailyRecapTest : TestCase() {
 
   fun setContent(
       navigateBack: () -> Unit = mockNav::goBack,
-      navigateTo: () -> Unit = mockNav::navigateToAddMeal,
+      navigateTo: (String?) -> Unit = mockNav::navigateToAddMeal,
       viewModel: DailyRecapViewModel = this.viewModel,
       isFetching: Boolean = false
   ) {
     every { viewModel.isFetching.value } returns isFetching
-    composeTestRule.setContent { DailyRecapScreen(navigateBack, navigateTo, viewModel, mockk()) }
+    composeTestRule.setContent { DailyRecapScreen(navigateBack, navigateTo, viewModel) }
   }
 
   @Test
@@ -143,10 +141,12 @@ class DailyRecapTest : TestCase() {
 
     ComposeScreen.onComposeScreen<MealListScreen>(composeTestRule) {
       mealCard { assertIsDisplayed() }
+
       mealName {
         assertIsDisplayed()
         assertTextEquals("Meal 1")
       }
+
       mealCalories {
         assertIsDisplayed()
         assertTextEquals("10.0 kcal")

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
@@ -62,11 +62,7 @@ class IngredientTest : TestCase() {
     val navigateBack = { mockNav.goBack() }
     val navigateForward = { mockNav.navigateToNutrition() }
     val testMeal =
-        Meal(
-            occasion = MealOccasion.OTHER,
-            name = "Test Meal",
-            mealID = 0,
-            ingredients = testIngredients)
+        Meal(occasion = MealOccasion.OTHER, name = "Test Meal", ingredients = testIngredients)
 
     mockMealViewModel.setMealData(testMeal)
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/NutritionalInformationTest.kt
@@ -55,7 +55,6 @@ class NutritionalInfoTest : TestCase() {
   private val meal =
       Meal(
           name = "Steak and frites",
-          mealID = 1,
           ingredients =
               mutableListOf(
                   Ingredient(

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/MealViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/MealViewModelTest.kt
@@ -39,14 +39,13 @@ class MealViewModelTest {
 
     val mealDao = mockk<MealDao>()
 
-    val meal = Meal(occasion = MealOccasion.OTHER, name = "Test Meal")
+    val meal = Meal(occasion = MealOccasion.OTHER, name = "Test Meal", id = "firebase123")
 
     every { mealDao.getMealById(any()) } returns meal
     coEvery { mealRepo.getMealById(any()) } returns meal
 
     viewModel = MealViewModel(mealRepo)
     viewModel.setMealData(meal)
-    viewModel.updateMealData(id = "firebase123")
   }
 
   @After
@@ -199,6 +198,26 @@ class MealViewModelTest {
     viewModel.setMealData(id)
 
     coVerify { mealRepo.getMealById(any()) }
+
+    // Since default meal returns different IDs
+    val default = Meal.default().copy(id = viewModel.meal.value.id)
+    assertThat(viewModel.meal.value, `is`(default))
+  }
+
+  @Test
+  fun setMealData_withEmptyId_givesDefaultMeal() = runTest {
+    val id = ""
+    viewModel.setMealData(id)
+
+    // Since default meal returns different IDs
+    val default = Meal.default().copy(id = viewModel.meal.value.id)
+    assertThat(viewModel.meal.value, `is`(default))
+  }
+
+  @Test
+  fun setMealData_withNullId_givesDefaultMeal() = runTest {
+    val id = null
+    viewModel.setMealData(id)
 
     // Since default meal returns different IDs
     val default = Meal.default().copy(id = viewModel.meal.value.id)

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/dailyRecap/DailyRecapViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/dailyRecap/DailyRecapViewModelTest.kt
@@ -37,7 +37,6 @@ class DailyRecapViewModelTest {
 
   private val testMeal =
       Meal(
-          mealID = 1,
           name = "Meal 1",
           ingredients =
               mutableListOf(

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -55,7 +55,7 @@ class MainActivity : ComponentActivity() {
 
           composable(Route.Register) { LoginScreen(navigation::navigateToHome) }
           composable(Route.AddMeal + "/{mId}") { backStackEntry ->
-            val mealId = backStackEntry.arguments?.getString("mId")?.toLong()
+            val mealId = backStackEntry.arguments?.getString("mId")
             AddMealFlow(
                 goBack = navigation::goBack,
                 navigateToHome = navigation::navigateToHome,

--- a/app/src/main/java/com/github/se/polyfit/data/api/SpoonacularAPI.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/api/SpoonacularAPI.kt
@@ -125,13 +125,10 @@ class SpoonacularApiCaller {
         if (recipeInformation.status == APIResponse.SUCCESS) {
           val newMeal =
               Meal(
-                  MealOccasion.OTHER, // New Meal should default to no occasion
-                  apiResponse.category,
-                  apiResponse.recipes.first().toLong(),
-                  20.0,
-                  recipeInformation.ingredients.toMutableList(),
-                  // firebase id not defined yet because no calls to store the information
-                  "")
+                  occasion = MealOccasion.OTHER, // New Meal should default to no occasion
+                  name = apiResponse.category,
+                  mealTemp = 20.0,
+                  ingredients = recipeInformation.ingredients.toMutableList())
 
           meal = newMeal
         }

--- a/app/src/main/java/com/github/se/polyfit/data/local/dao/MealDao.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/local/dao/MealDao.kt
@@ -24,20 +24,14 @@ interface MealDao {
     return meals.flatMap { it.ingredients }
   }
 
-  @Insert(onConflict = OnConflictStrategy.REPLACE) fun insert(meal: MealEntity): Long
+  @Insert(onConflict = OnConflictStrategy.REPLACE) fun insert(meal: MealEntity)
 
   // Converts the Meal object to a MealEntity and inserts it into the database.
   // Returns the ID of the inserted meal.
-  fun insert(meal: Meal): Long {
-    return insert(MealEntity.toMealEntity(meal))
-  }
-
-  @Query("SELECT * FROM MealTable WHERE firebaseId = :id LIMIT 1 ")
-  fun getMealEntityByFirebaseID(id: String): MealEntity?
-
-  fun getMealByFirebaseID(id: String): Meal? {
-    val meal = getMealEntityByFirebaseID(id)
-    return meal?.toMeal()
+  fun insert(meal: Meal): String {
+    val mealEntity = MealEntity.toMealEntity(meal)
+    insert(mealEntity)
+    return mealEntity.id
   }
 
   @Query("SELECT * FROM MEALTABLE WHERE createdAt >= :date ")
@@ -46,9 +40,7 @@ interface MealDao {
   @Query("SELECT * FROM MEALTABLE WHERE createdAt == :date ")
   fun getMealsCreatedOnDate(date: LocalDate): List<Meal>
 
-  @Query("DELETE FROM MealTable WHERE firebaseId = :id") fun deleteByFirebaseID(id: String)
-
-  @Query("DELETE FROM MealTable WHERE id = :id") fun deleteByDatabaseID(id: Long)
+  @Query("DELETE FROM MealTable WHERE id = :id") fun deleteById(id: String)
 
   @Query("DELETE FROM MealTable") fun deleteAll()
 
@@ -57,9 +49,9 @@ interface MealDao {
    * between meals who do not have yet a firebase ID
    */
   @Query("SELECT * FROM MealTable WHERE id = :id LIMIT 1 ")
-  fun getMealEntityByDatabaseID(id: Long): MealEntity?
+  fun getMealEntityById(id: String): MealEntity?
 
-  fun getMealByDatabaseID(id: Long): Meal? {
-    return getMealEntityByDatabaseID(id)?.toMeal()
+  fun getMealById(id: String): Meal? {
+    return getMealEntityById(id)?.toMeal()
   }
 }

--- a/app/src/main/java/com/github/se/polyfit/data/local/database/MealDatabase.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/local/database/MealDatabase.kt
@@ -1,9 +1,12 @@
 package com.github.se.polyfit.data.local.database
 
+import androidx.room.AutoMigration
 import androidx.room.Database
+import androidx.room.DeleteColumn
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverter
 import androidx.room.TypeConverters
+import androidx.room.migration.AutoMigrationSpec
 import com.github.se.polyfit.data.local.dao.MealDao
 import com.github.se.polyfit.data.local.entity.MealEntity
 import com.github.se.polyfit.model.ingredient.Ingredient
@@ -13,7 +16,13 @@ import com.google.common.reflect.TypeToken
 import com.google.gson.Gson
 import java.time.LocalDate
 
-@Database(entities = [MealEntity::class], version = 1)
+@Database(
+    entities = [MealEntity::class],
+    version = 3,
+    autoMigrations =
+        [
+            AutoMigration(from = 1, to = 2, spec = MealDatabase.RemoveMealId::class),
+            AutoMigration(from = 2, to = 3, spec = MealDatabase.RemoveFirebaseId::class)])
 @TypeConverters(
     NutritionalInformationConverter::class,
     IngredientListConverter::class,
@@ -21,6 +30,12 @@ import java.time.LocalDate
     TagListConverter::class)
 abstract class MealDatabase : RoomDatabase() {
   abstract fun mealDao(): MealDao
+
+  @DeleteColumn.Entries(DeleteColumn(tableName = "MealTable", columnName = "mealID"))
+  class RemoveMealId : AutoMigrationSpec
+
+  @DeleteColumn.Entries(DeleteColumn(tableName = "MealTable", columnName = "firebaseId"))
+  class RemoveFirebaseId : AutoMigrationSpec
 }
 
 class NutritionalInformationConverter {

--- a/app/src/main/java/com/github/se/polyfit/data/local/entity/MealEntity.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/local/entity/MealEntity.kt
@@ -11,20 +11,18 @@ import java.time.LocalDate
 
 @Entity(tableName = "MealTable")
 data class MealEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: String,
     val occasion: MealOccasion,
     val name: String,
-    val mealID: Long,
     val mealTemp: Double,
     val nutritionalInformation: NutritionalInformation,
     val ingredients: MutableList<Ingredient>,
-    val firebaseId: String,
     val createdAt: LocalDate,
     val tags: MutableList<MealTag>
 ) {
 
   fun toMeal(): Meal {
-    return Meal(occasion, name, mealID, mealTemp, ingredients, firebaseId, createdAt, tags)
+    return Meal(occasion, name, id, mealTemp, ingredients, createdAt, tags)
   }
 
   companion object {
@@ -32,11 +30,10 @@ data class MealEntity(
       return MealEntity(
           occasion = meal.occasion,
           name = meal.name,
-          mealID = meal.mealID,
+          id = meal.id,
           mealTemp = meal.mealTemp,
           nutritionalInformation = meal.nutritionalInformation,
           ingredients = meal.ingredients,
-          firebaseId = meal.firebaseId,
           createdAt = meal.createdAt,
           tags = meal.tags)
     }

--- a/app/src/main/java/com/github/se/polyfit/data/repository/MealRepository.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/repository/MealRepository.kt
@@ -83,7 +83,7 @@ class MealRepository(
     } else {
       isDataOutdated = true
     }
-    mealDao.deleteById(id)
+    withContext(dispatcher) { mealDao.deleteById(id) }
   }
 
   /** Returns a list of unique ingredients */
@@ -94,13 +94,11 @@ class MealRepository(
   private suspend fun updateFirebase() {
     withContext(dispatcher) {
       mealDao.getAllMeals().forEach {
-        if (it != null) {
-          try {
-            mealFirebaseRepository.storeMeal(it)
-          } catch (e: Exception) {
-            Log.e("MealRepository", "Failed to store meal: ${e.message}")
-            throw Exception("Failed to store meal: ${e.message}")
-          }
+        try {
+          mealFirebaseRepository.storeMeal(it)
+        } catch (e: Exception) {
+          Log.e("MealRepository", "Failed to store meal: ${e.message}")
+          throw Exception("Failed to store meal: ${e.message}")
         }
       }
     }

--- a/app/src/main/java/com/github/se/polyfit/data/repository/MealRepository.kt
+++ b/app/src/main/java/com/github/se/polyfit/data/repository/MealRepository.kt
@@ -32,26 +32,21 @@ class MealRepository(
    */
   suspend fun storeMeal(meal: Meal): DocumentReference? {
     Log.d("MealRepository", "Storing meal: $meal")
+    var returnVal: DocumentReference? = null
     return withContext(dispatcher) {
       try {
-
         if (checkConnectivity.checkConnection()) {
           if (isDataOutdated) {
             updateFirebase()
             isDataOutdated = false
-            mealDao.insert(meal)
-            return@withContext mealFirebaseRepository.storeMeal(meal).await()
-          } else {
-
-            val documentReference = mealFirebaseRepository.storeMeal(meal).await()
-            mealDao.insert(meal)
-            return@withContext documentReference
           }
+          returnVal = mealFirebaseRepository.storeMeal(meal).await()
         } else {
           isDataOutdated = true
-          mealDao.insert(meal)
-          return@withContext null
         }
+
+        mealDao.insert(meal)
+        return@withContext returnVal
       } catch (e: Exception) {
         Log.e("MealRepository", "Failed to store meal: ${e.message}")
         throw Exception("Failed to store meal: ${e.message}")
@@ -59,12 +54,8 @@ class MealRepository(
     }
   }
 
-  fun getMealByFirebaseID(firebaseID: String): Meal? {
-    return mealDao.getMealByFirebaseID(firebaseID)
-  }
-
-  fun getMealById(mealId: Long): Meal? {
-    return mealDao.getMealByDatabaseID(mealId)
+  fun getMealById(mealId: String): Meal? {
+    return mealDao.getMealById(mealId)
   }
 
   fun getAllMeals(): List<Meal> {
@@ -75,7 +66,7 @@ class MealRepository(
     return withContext(this.dispatcher) { mealDao.getMealsCreatedOnDate(date) }
   }
 
-  suspend fun deleteMeal(firebaseID: String) {
+  suspend fun deleteMeal(id: String) {
     if (checkConnectivity.checkConnection()) {
       if (isDataOutdated) {
         updateFirebase()
@@ -83,7 +74,7 @@ class MealRepository(
       }
       withContext(dispatcher) {
         try {
-          mealFirebaseRepository.deleteMeal(firebaseID).await()
+          mealFirebaseRepository.deleteMeal(id).await()
         } catch (e: Exception) {
           Log.e("MealRepository", "Failed to delete meal: ${e.message}")
           throw Exception("Failed to delete meal: ${e.message}")
@@ -92,7 +83,7 @@ class MealRepository(
     } else {
       isDataOutdated = true
     }
-    mealDao.deleteByFirebaseID(firebaseID)
+    mealDao.deleteById(id)
   }
 
   /** Returns a list of unique ingredients */

--- a/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/meal/Meal.kt
@@ -5,35 +5,30 @@ import com.github.se.polyfit.model.ingredient.Ingredient
 import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import java.time.LocalDate
+import java.util.UUID
 
 // modeled after the log meal api
 data class Meal(
     var occasion: MealOccasion,
     var name: String,
-    val mealID: Long,
-    // represent the ideal temperature at which should be eaten at,
-    // usefull for later features
+    val id: String = UUID.randomUUID().toString(),
     val mealTemp: Double = 20.0,
     val ingredients: MutableList<Ingredient> = mutableListOf(),
-    var firebaseId: String = "",
     var createdAt: LocalDate = LocalDate.now(),
     val tags: MutableList<MealTag> = mutableListOf()
 ) {
   var nutritionalInformation: NutritionalInformation = NutritionalInformation()
 
   init {
-    require(mealID >= 0)
-
     updateMeal()
   }
 
   fun deepCopy(
       occasion: MealOccasion = this.occasion,
       name: String = this.name,
-      mealID: Long = this.mealID,
+      id: String = this.id,
       mealTemp: Double = this.mealTemp,
       ingredients: MutableList<Ingredient> = this.ingredients,
-      firebaseId: String = this.firebaseId,
       createdAt: LocalDate = this.createdAt,
       tags: MutableList<MealTag> = this.tags
   ): Meal {
@@ -43,10 +38,9 @@ data class Meal(
     return Meal(
         occasion = occasion,
         name = name,
-        mealID = mealID,
+        id = id,
         mealTemp = mealTemp,
         ingredients = newIngredients,
-        firebaseId = firebaseId,
         createdAt = createdAt,
         tags = newTags)
   }
@@ -55,13 +49,12 @@ data class Meal(
     if (this === other) return true
     if (other !is Meal) return false
 
-    if (mealID != other.mealID) return false
+    if (id != other.id) return false
     if (name != other.name) return false
     if (occasion != other.occasion) return false
     if (mealTemp != other.mealTemp) return false
     if (nutritionalInformation != other.nutritionalInformation) return false
     if (ingredients != other.ingredients) return false
-    if (firebaseId != other.firebaseId) return false
     if (createdAt != other.createdAt) return false
     if (tags != other.tags) return false
 
@@ -69,13 +62,12 @@ data class Meal(
   }
 
   override fun hashCode(): Int {
-    var result = mealID.toInt()
+    var result = id.hashCode()
     result = 31 * result + name.hashCode()
     result = 31 * result + occasion.hashCode()
     result = 31 * result + mealTemp.hashCode()
     result = 31 * result + nutritionalInformation.hashCode()
     result = 31 * result + ingredients.hashCode()
-    result = 31 * result + firebaseId.hashCode()
     result = 31 * result + createdAt.hashCode()
     result = 31 * result + tags.hashCode()
 
@@ -134,11 +126,10 @@ data class Meal(
 
     fun serialize(data: Meal): Map<String, Any> {
       return mutableMapOf<String, Any>().apply {
-        this["mealID"] = data.mealID
+        this["id"] = data.id
         this["occasion"] = data.occasion.name
         this["name"] = data.name
         this["mealTemp"] = data.mealTemp
-        this["nutritionalInformation"] = listOf<Any>() // TODO: Remove after M2 Grading
         this["ingredients"] = data.ingredients.map { Ingredient.serialize(it) }
         this["createdAt"] = data.createdAt.toString()
         this["tags"] = data.tags.map { MealTag.serialize(it) }
@@ -147,7 +138,7 @@ data class Meal(
 
     fun deserialize(data: Map<String, Any>): Meal {
       return try {
-        val mealID = data["mealID"] as Long
+        val id = data["id"] as String
         val occasion = data["occasion"].let { MealOccasion.valueOf(it as String) }
         val mealTemp = data["mealTemp"] as Double
         val name = data["name"] as String
@@ -159,7 +150,7 @@ data class Meal(
             Meal(
                 occasion = occasion,
                 name = name,
-                mealID = mealID,
+                id = id,
                 mealTemp = mealTemp,
                 createdAt = createdAt,
                 tags = tags)
@@ -181,10 +172,9 @@ data class Meal(
       return Meal(
           occasion = MealOccasion.OTHER,
           name = "",
-          mealID = 0,
+          id = UUID.randomUUID().toString(),
           mealTemp = 20.0,
           ingredients = mutableListOf(),
-          firebaseId = "",
           createdAt = LocalDate.now(),
           tags = mutableListOf())
     }

--- a/app/src/main/java/com/github/se/polyfit/ui/components/list/MealList.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/list/MealList.kt
@@ -17,22 +17,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.github.se.polyfit.model.meal.Meal
 import com.github.se.polyfit.model.meal.MealOccasion
 import com.github.se.polyfit.model.nutritionalInformation.MeasurementUnit
 import com.github.se.polyfit.ui.theme.BorderPurple
 import com.github.se.polyfit.ui.theme.PrimaryPink
 import com.github.se.polyfit.ui.theme.PurpleGrey40
-import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @Composable
 fun MealList(
     meals: List<Meal>,
     occasion: MealOccasion,
-    navigateTo: () -> Unit,
+    navigateTo: (String?) -> Unit,
     modifier: Modifier = Modifier,
-    mealViewModel: MealViewModel = hiltViewModel()
 ) {
   val filteredMeals = meals.filter { it.occasion == occasion }
   val totalCalories = filteredMeals.sumOf { it.calculateTotalCalories() }.toString()
@@ -60,12 +57,7 @@ fun MealList(
                     modifier = Modifier.testTag("TotalCalories"))
               }
           HorizontalDivider(color = PrimaryPink)
-          filteredMeals.forEach { meal ->
-            MealCard(meal) {
-              mealViewModel.setMealData(meal)
-              navigateTo()
-            }
-          }
+          filteredMeals.forEach { meal -> MealCard(meal) { navigateTo(meal.id) } }
         }
       }
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/flow/AddMealFlow.kt
@@ -16,7 +16,7 @@ import com.github.se.polyfit.viewmodel.meal.MealViewModel
 fun AddMealFlow(
     goBack: () -> Unit,
     navigateToHome: () -> Unit,
-    mealId: Long? = null,
+    mealId: String? = null,
     mealViewModel: MealViewModel = hiltViewModel<MealViewModel>(),
 ) {
   val navController = rememberNavController()

--- a/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
@@ -21,7 +21,7 @@ class Navigation(private val navHostController: NavHostController) {
   }
 
   fun navigateToAddMeal(mealDatabaseId: String? = null) {
-    if (mealDatabaseId == null) {
+    if (mealDatabaseId.isNullOrEmpty()) {
       navigateTo(Route.AddMeal)
     } else {
       navigateTo(Route.AddMeal + "/$mealDatabaseId")

--- a/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
@@ -20,7 +20,7 @@ class Navigation(private val navHostController: NavHostController) {
     navigateTo(Route.Nutrition)
   }
 
-  fun navigateToAddMeal(mealDatabaseId: Long? = null) {
+  fun navigateToAddMeal(mealDatabaseId: String? = null) {
     if (mealDatabaseId == null) {
       navigateTo(Route.AddMeal)
     } else {

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/DailyRecapScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/DailyRecapScreen.kt
@@ -24,14 +24,12 @@ import com.github.se.polyfit.ui.components.list.MealList
 import com.github.se.polyfit.ui.components.scaffold.SimpleTopBar
 import com.github.se.polyfit.ui.components.selector.DateSelector
 import com.github.se.polyfit.viewmodel.dailyRecap.DailyRecapViewModel
-import com.github.se.polyfit.viewmodel.meal.MealViewModel
 
 @Composable
 fun DailyRecapScreen(
     navigateBack: () -> Unit,
-    navigateTo: () -> Unit,
+    navigateTo: (String?) -> Unit,
     dailyRecapViewModel: DailyRecapViewModel = hiltViewModel(),
-    mealViewModel: MealViewModel = hiltViewModel() // TODO: Remove when stop reusing mealviewmodel
 ) {
   val context = LocalContext.current
   val meals by dailyRecapViewModel.meals.collectAsState()
@@ -54,8 +52,7 @@ fun DailyRecapScreen(
                 meals = meals,
                 occasion = occasion,
                 navigateTo = navigateTo,
-                modifier = Modifier.padding(0.dp, 8.dp),
-                mealViewModel = mealViewModel)
+                modifier = Modifier.padding(0.dp, 8.dp))
           }
         }
       } else {

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/OverviewScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/OverviewScreen.kt
@@ -219,7 +219,7 @@ fun OverviewScreen(
         imageBitmap = bitmap
 
         showPictureDialog = false
-        var id: Long? = runBlocking(Dispatchers.IO) { overviewViewModel.storeMeal(imageBitmap) }
+        val id: String? = runBlocking(Dispatchers.IO) { overviewViewModel.storeMeal(imageBitmap) }
         navigation.navigateToAddMeal(id)
       }
 

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/dailyRecap/DailyRecapViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/dailyRecap/DailyRecapViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.se.polyfit.viewmodel.dailyRecap
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.se.polyfit.data.repository.MealRepository
@@ -32,6 +33,7 @@ class DailyRecapViewModel @Inject constructor(private val mealRepository: MealRe
 
       val newMeals = mealRepository.getMealsOnDate(date).filter { it.isComplete() }
       withContext(Dispatchers.Main) {
+        Log.v("new meals", newMeals.toString())
         _meals.value = newMeals
       } // FYI: UI updates only on Main Thread
 

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -36,7 +36,7 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
   }
 
   fun setMealData(mealId: String?) {
-    if (mealId == null) {
+    if (mealId.isNullOrEmpty()) {
       _meal.value = Meal.default()
       return
     }
@@ -54,13 +54,12 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
   fun updateMealData(
       mealOccasion: MealOccasion = _meal.value.occasion,
       name: String = _meal.value.name,
-      id: String = _meal.value.id,
       mealTemp: Double = _meal.value.mealTemp,
       ingredients: MutableList<Ingredient> = _meal.value.ingredients,
       createdAt: LocalDate = _meal.value.createdAt,
       tags: MutableList<MealTag> = _meal.value.tags
   ) {
-    _meal.value = Meal(mealOccasion, name, id, mealTemp, ingredients, createdAt, tags)
+    _meal.value = Meal(mealOccasion, name, _meal.value.id, mealTemp, ingredients, createdAt, tags)
   }
 
   fun setMealCreatedAt(createdAt: LocalDate) {

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/MealViewModel.kt
@@ -35,7 +35,7 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
     _meal.value = meal
   }
 
-  fun setMealData(mealId: Long?) {
+  fun setMealData(mealId: String?) {
     if (mealId == null) {
       _meal.value = Meal.default()
       return
@@ -54,15 +54,13 @@ class MealViewModel @Inject constructor(private val mealRepo: MealRepository) : 
   fun updateMealData(
       mealOccasion: MealOccasion = _meal.value.occasion,
       name: String = _meal.value.name,
-      mealID: Long = _meal.value.mealID,
+      id: String = _meal.value.id,
       mealTemp: Double = _meal.value.mealTemp,
       ingredients: MutableList<Ingredient> = _meal.value.ingredients,
-      firebaseID: String = _meal.value.firebaseId,
       createdAt: LocalDate = _meal.value.createdAt,
       tags: MutableList<MealTag> = _meal.value.tags
   ) {
-    _meal.value =
-        Meal(mealOccasion, name, mealID, mealTemp, ingredients, firebaseID, createdAt, tags)
+    _meal.value = Meal(mealOccasion, name, id, mealTemp, ingredients, createdAt, tags)
   }
 
   fun setMealCreatedAt(createdAt: LocalDate) {

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/meal/OverviewViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/meal/OverviewViewModel.kt
@@ -16,7 +16,7 @@ class OverviewViewModel
 constructor(private val mealDao: MealDao, private val spoonacularApiCaller: SpoonacularApiCaller) :
     ViewModel() {
 
-  fun storeMeal(imageBitmap: Bitmap?): Long? {
+  fun storeMeal(imageBitmap: Bitmap?): String? {
     if (imageBitmap == null) {
       Log.e("OverviewViewModel", "Image is null")
       return null
@@ -34,8 +34,8 @@ constructor(private val mealDao: MealDao, private val spoonacularApiCaller: Spoo
     }
   }
 
-  fun deleteByDBId(mealDatabaseId: Long) {
-    mealDao.deleteByDatabaseID(mealDatabaseId)
+  fun deleteById(mealDatabaseId: String) {
+    mealDao.deleteById(mealDatabaseId)
   }
 
   fun getMealsByCalorieRange(minCalories: Double, maxCalories: Double): List<Meal> {

--- a/app/src/test/java/com/github/se/polyfit/data/post/PostTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/data/post/PostTest.kt
@@ -87,14 +87,11 @@ class PostTest {
 
   @Test
   fun `default method returns expected Post object`() {
-    val post = Post.default()
+    val defaultMeal = Meal.default()
+    val post = Post.default().copy(meal = defaultMeal)
     val expectedPost =
         Post(
-            "testId",
-            "Description",
-            Location(0.0, 0.0, 10.0, "EPFL"),
-            Meal.default(),
-            LocalDate.now())
+            "testId", "Description", Location(0.0, 0.0, 10.0, "EPFL"), defaultMeal, LocalDate.now())
 
     assertEquals(expectedPost, post)
   }
@@ -146,6 +143,7 @@ class PostTest {
 
   @Test
   fun deserializePost() {
+    val defaultMeal = Meal.default()
     val post =
         Post.deserialize(
             mapOf(
@@ -157,7 +155,7 @@ class PostTest {
                         "latitude" to 0.0,
                         "altitude" to 10.0,
                         "name" to "EPFL"),
-                "meal" to Meal.default().serialize(),
+                "meal" to defaultMeal.serialize(),
                 "createdAt" to
                     mapOf(
                         "year" to 2021.toLong(),
@@ -168,13 +166,14 @@ class PostTest {
             "userId",
             "description",
             Location(0.0, 0.0, 10.0, "EPFL"),
-            Meal.default(),
+            defaultMeal,
             LocalDate.of(2021, 10, 10))
     assertEquals(expectedPost, post)
   }
 
   @Test
   fun deserializePostWithDifferentLocation() {
+    val defaultMeal = Meal.default()
     val post =
         Post.deserialize(
             mapOf(
@@ -186,7 +185,7 @@ class PostTest {
                         "latitude" to 20.0,
                         "altitude" to 30.0,
                         "name" to "MIT"),
-                "meal" to Meal.default().serialize(),
+                "meal" to defaultMeal.serialize(),
                 "createdAt" to
                     mapOf(
                         "year" to 2021.toLong(),
@@ -197,13 +196,14 @@ class PostTest {
             "userId",
             "description",
             Location(10.0, 20.0, 30.0, "MIT"),
-            Meal.default(),
+            defaultMeal,
             LocalDate.of(2021, 10, 10))
     assertEquals(expectedPost, post)
   }
 
   @Test
   fun deserializePostWithDifferentUserId() {
+    val defaultMeal = Meal.default()
     val post =
         Post.deserialize(
             mapOf(
@@ -215,7 +215,7 @@ class PostTest {
                         "latitude" to 0.0,
                         "altitude" to 10.0,
                         "name" to "EPFL"),
-                "meal" to Meal.default().serialize(),
+                "meal" to defaultMeal.serialize(),
                 "createdAt" to
                     mapOf(
                         "year" to 2021.toLong(),
@@ -226,13 +226,14 @@ class PostTest {
             "differentUserId",
             "description",
             Location(0.0, 0.0, 10.0, "EPFL"),
-            Meal.default(),
+            defaultMeal,
             LocalDate.of(2021, 10, 10))
     assertEquals(expectedPost, post)
   }
 
   @Test
   fun deserializePostWithDifferentDescription() {
+    val defaultMeal = Meal.default()
     val post =
         Post.deserialize(
             mapOf(
@@ -244,7 +245,7 @@ class PostTest {
                         "latitude" to 0.0,
                         "altitude" to 10.0,
                         "name" to "EPFL"),
-                "meal" to Meal.default().serialize(),
+                "meal" to defaultMeal.serialize(),
                 "createdAt" to
                     mapOf(
                         "year" to 2021.toLong(),
@@ -255,7 +256,7 @@ class PostTest {
             "userId",
             "differentDescription",
             Location(0.0, 0.0, 10.0, "EPFL"),
-            Meal.default(),
+            defaultMeal,
             LocalDate.of(2021, 10, 10))
     assertEquals(expectedPost, post)
   }

--- a/app/src/test/java/com/github/se/polyfit/data/processor/LocalDataProcessorTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/data/processor/LocalDataProcessorTest.kt
@@ -93,7 +93,6 @@ class LocalDataProcessorTest {
       Meal(
           occasion = occasion,
           name = name,
-          mealID = 1,
           mealTemp = 20.0,
           ingredients =
               mutableListOf(
@@ -108,7 +107,7 @@ class LocalDataProcessorTest {
                               Nutrient("protein", 10.0, MeasurementUnit.G),
                               Nutrient("carbs", 20.0, MeasurementUnit.G),
                               Nutrient("fat", 5.0, MeasurementUnit.ML))))),
-          firebaseId = "1",
+          id = "1",
           createdAt = LocalDate.now())
 
   private fun createCustomMeal(

--- a/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/meal/MealTest.kt
@@ -8,6 +8,7 @@ import com.github.se.polyfit.model.nutritionalInformation.NutritionalInformation
 import io.mockk.every
 import io.mockk.mockkStatic
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import org.junit.Assert.assertEquals
@@ -24,7 +25,7 @@ class MealTest {
 
   @Test
   fun `Meal addIngredient should update meal`() {
-    val meal = Meal(MealOccasion.DINNER, "eggs", 1, 102.2)
+    val meal = Meal(MealOccasion.DINNER, name = "eggs", mealTemp = 102.2)
     val newNutritionalInformation =
         NutritionalInformation(mutableListOf(Nutrient("calcium", 1.0, MeasurementUnit.G)))
 
@@ -39,13 +40,12 @@ class MealTest {
     val meal =
         Meal(
             MealOccasion.DINNER,
-            "eggs",
-            1.toLong(),
-            102.2,
+            name = "eggs",
+            mealTemp = 102.2,
             createdAt = LocalDate.parse("2021-01-01"),
             tags = mutableListOf(MealTag("name of tag", MealTagColor.BLUE)))
     val serializedMeal = Meal.serialize(meal)
-    assertEquals(1.toLong(), serializedMeal["mealID"])
+    assertEquals(meal.id, serializedMeal["id"])
     assertEquals(MealOccasion.DINNER.name, serializedMeal["occasion"])
     assertEquals("eggs", serializedMeal["name"])
     assertEquals(102.2, serializedMeal["mealTemp"])
@@ -59,7 +59,7 @@ class MealTest {
   fun `Meal deserialize should return null if data is incorrect`() {
     val data =
         mapOf(
-            "mealID" to 1,
+            "id" to UUID.randomUUID(),
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to "wrongValue",
@@ -70,9 +70,10 @@ class MealTest {
 
   @Test
   fun `Meal deserialize should return meal if data is correct`() {
+    val uuid = UUID.randomUUID().toString()
     val data =
         mapOf(
-            "mealID" to 1.toLong(),
+            "id" to uuid,
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to 102.2,
@@ -80,7 +81,7 @@ class MealTest {
             "tags" to mutableListOf(MealTag("name of tag", MealTagColor.BLUE).serialize()))
     val meal = Meal.deserialize(data)
     assertNotNull(meal)
-    assertEquals(1.toLong(), meal.mealID)
+    assertEquals(uuid, meal.id)
     assertEquals(MealOccasion.DINNER, meal.occasion)
     assertEquals("eggs", meal.name)
     assertEquals(102.2, meal.mealTemp, 0.001)
@@ -93,7 +94,7 @@ class MealTest {
   fun `testing deserialize with Firebase type`() {
     val data: Map<String, Any> =
         mapOf(
-            "mealID" to 1.toLong(),
+            "id" to UUID.randomUUID().toString(),
             "occasion" to "DINNER",
             "name" to "eggs",
             "mealTemp" to 102.2,
@@ -111,7 +112,6 @@ class MealTest {
         Meal(
             MealOccasion.DINNER,
             name = "",
-            mealID = 1,
             mealTemp = 102.2,
             ingredients = mutableListOf(Ingredient("milk", 1, 102.0, MeasurementUnit.MG)))
 
@@ -121,12 +121,7 @@ class MealTest {
   @Test
   fun `meal without ingredients is incomplete`() {
     val meal =
-        Meal(
-            MealOccasion.DINNER,
-            name = "eggs",
-            mealID = 1,
-            mealTemp = 102.2,
-            ingredients = mutableListOf())
+        Meal(MealOccasion.DINNER, name = "eggs", mealTemp = 102.2, ingredients = mutableListOf())
 
     assertEquals(false, meal.isComplete())
   }
@@ -137,7 +132,6 @@ class MealTest {
         Meal(
             MealOccasion.DINNER,
             name = "eggs",
-            mealID = 1,
             mealTemp = 102.2,
             ingredients = mutableListOf(Ingredient("milk", 1, 102.0, MeasurementUnit.MG)))
 
@@ -150,7 +144,6 @@ class MealTest {
         Meal(
             MealOccasion.DINNER,
             name = "eggs",
-            mealID = 1,
             mealTemp = 102.2,
             ingredients =
                 mutableListOf(
@@ -171,7 +164,6 @@ class MealTest {
         Meal(
             MealOccasion.DINNER,
             name = "eggs",
-            mealID = 1,
             mealTemp = 102.2,
             ingredients =
                 mutableListOf(
@@ -194,7 +186,6 @@ class MealTest {
         Meal(
             MealOccasion.DINNER,
             name = "eggs",
-            mealID = 1,
             mealTemp = 102.2,
             ingredients =
                 mutableListOf(

--- a/app/src/test/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
@@ -26,7 +26,7 @@ class NavigationTest {
 
   @Test
   fun navigateToAddMeal_withMealDatabaseId_navigatesToCorrectRoute() {
-    val mealDatabaseId = 1L
+    val mealDatabaseId = "1L"
     val expectedRoute = Route.AddMeal + "/$mealDatabaseId"
     every { navHostController.navigate(expectedRoute) } just Runs
 

--- a/app/src/test/java/com/github/se/polyfit/viewmodel/meal/OverviewViewModelTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/viewmodel/meal/OverviewViewModelTest.kt
@@ -38,8 +38,8 @@ class OverviewViewModelTest {
     val bitmap: Bitmap = mockk()
     val meal: Meal = mockk()
     every { mockSpoonacularApiCaller.getMealsFromImage(bitmap) } returns meal
-    every { mockMealDao.insert(meal) } returns 1
-    Assert.assertEquals(1.toLong(), overviewViewModel.storeMeal(bitmap))
+    every { mockMealDao.insert(meal) } returns "1"
+    Assert.assertEquals("1", overviewViewModel.storeMeal(bitmap))
   }
 
   @Test
@@ -51,14 +51,14 @@ class OverviewViewModelTest {
 
   @Test
   fun deleteByDBId_deletesMeal() {
-    val id = 1L
-    every { mockMealDao.deleteByDatabaseID(id) } returns Unit
+    val id = "1L"
+    every { mockMealDao.deleteById(id) } returns Unit
 
     // Call the method under test
-    overviewViewModel.deleteByDBId(id)
+    overviewViewModel.deleteById(id)
 
     // Verify that the method was called with the correct parameters
-    verify { mockMealDao.deleteByDatabaseID(id) }
+    verify { mockMealDao.deleteById(id) }
   }
 
   @Test
@@ -66,7 +66,6 @@ class OverviewViewModelTest {
     // Prepare the meals
     val meal1 =
         Meal(
-            mealID = 1,
             name = "Meal 1",
             occasion = MealOccasion.BREAKFAST,
             ingredients =
@@ -81,7 +80,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 100.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
-            mealID = 2,
             name = "Meal 2",
             occasion = MealOccasion.LUNCH,
             ingredients =
@@ -97,7 +95,6 @@ class OverviewViewModelTest {
 
     val meal3 =
         Meal(
-            mealID = 3,
             name = "Meal 3",
             occasion = MealOccasion.DINNER,
             ingredients =
@@ -158,9 +155,9 @@ class OverviewViewModelTest {
   @Test
   fun getMealsByOccasion_returnsCorrectMeals() {
     // Prepare the meals
-    val meal1 = Meal(mealID = 1, name = "Breakfast Meal", occasion = MealOccasion.BREAKFAST)
-    val meal2 = Meal(mealID = 2, name = "Lunch Meal", occasion = MealOccasion.LUNCH)
-    val meal3 = Meal(mealID = 3, name = "Dinner Meal", occasion = MealOccasion.DINNER)
+    val meal1 = Meal(name = "Breakfast Meal", occasion = MealOccasion.BREAKFAST)
+    val meal2 = Meal(name = "Lunch Meal", occasion = MealOccasion.LUNCH)
+    val meal3 = Meal(name = "Dinner Meal", occasion = MealOccasion.DINNER)
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -177,9 +174,9 @@ class OverviewViewModelTest {
   @Test
   fun getMealsByOccasion_noMatchingMeals() {
     // Prepare the meals
-    val meal1 = Meal(mealID = 1, name = "Breakfast Meal", occasion = MealOccasion.BREAKFAST)
-    val meal2 = Meal(mealID = 2, name = "Lunch Meal", occasion = MealOccasion.LUNCH)
-    val meal3 = Meal(mealID = 3, name = "Dinner Meal", occasion = MealOccasion.DINNER)
+    val meal1 = Meal(name = "Breakfast Meal", occasion = MealOccasion.BREAKFAST)
+    val meal2 = Meal(name = "Lunch Meal", occasion = MealOccasion.LUNCH)
+    val meal3 = Meal(name = "Dinner Meal", occasion = MealOccasion.DINNER)
     val allMeals = listOf(meal1, meal2, meal3)
 
     // Mock the getAllMeals function in the dao
@@ -197,7 +194,6 @@ class OverviewViewModelTest {
     // Prepare the meals
     val meal1 =
         Meal(
-            mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
             ingredients =
@@ -212,7 +208,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
-            mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
             ingredients =
@@ -227,7 +222,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
-            mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
             ingredients =
@@ -261,7 +255,6 @@ class OverviewViewModelTest {
     // Prepare the meals
     val meal1 =
         Meal(
-            mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
             ingredients =
@@ -276,7 +269,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
-            mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
             ingredients =
@@ -291,7 +283,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
-            mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
             ingredients =
@@ -323,7 +314,6 @@ class OverviewViewModelTest {
     // Prepare the meals
     val meal1 =
         Meal(
-            mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
             ingredients =
@@ -338,7 +328,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
-            mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
             ingredients =
@@ -353,7 +342,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
-            mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
             ingredients =
@@ -395,7 +383,6 @@ class OverviewViewModelTest {
     // Prepare the meals
     val meal1 =
         Meal(
-            mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
             ingredients =
@@ -410,7 +397,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
-            mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
             ingredients =
@@ -425,7 +411,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
-            mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
             ingredients =
@@ -457,7 +442,6 @@ class OverviewViewModelTest {
     // Prepare the meals
     val meal1 =
         Meal(
-            mealID = 1,
             name = "Chicken Salad",
             occasion = MealOccasion.BREAKFAST,
             ingredients =
@@ -472,7 +456,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 150.0, MeasurementUnit.KCAL))))))
     val meal2 =
         Meal(
-            mealID = 2,
             name = "Beef Stew",
             occasion = MealOccasion.LUNCH,
             ingredients =
@@ -487,7 +470,6 @@ class OverviewViewModelTest {
                                 mutableListOf(Nutrient("calories", 250.0, MeasurementUnit.KCAL))))))
     val meal3 =
         Meal(
-            mealID = 3,
             name = "Chicken Soup",
             occasion = MealOccasion.DINNER,
             ingredients =
@@ -529,7 +511,6 @@ class OverviewViewModelTest {
     // Prepare the meals
     val meal1 =
         Meal(
-            mealID = 1,
             occasion = MealOccasion.BREAKFAST,
             name = "Chicken Salad",
             ingredients =


### PR DESCRIPTION
# Pull Request Overview

This PR streamlines our Meal's `id` to reduce confusion. Further, this allows us to be able to edit meals in the future, as currently we don't save our local database's id in our meal objects. This PR combines the local database id and firebase id into one, `id`, that will be the primary key in the local database and the document id in firebase.

## Note for Review
- Make sure you don't have anything in your local database (easiest way is to uninstall the app from your emulator and relaunch) to prevent parsing errors.
- If you try to view posts, this won't work because we have old meals stored in the database. We will purge all that data after this change. (we could run migrations, but since its all test data it would be a lot faster to just reset it)

## Changes

- **Update `MealDao`**: Remove methods that access via `firebaseId` and replaces them through `id` access. Also, reformats insert to return the `String` key.  
- **Update `MealDatabase`**: Runs the migrations to update the database
   - **Add database schema snapshots**: To migrate the local database, we must add a config in `build.gradle.kt` that stores the database format at each version.
- **Update `MealEntity`**: Removes the old columns
- **Update `MealFirebaseRepository`**: Since `id` will always be defined, removes `add` method and just always uses `set` (which will replace if existing, and add otherwise`.
- **Update `MealRepository`**: Simplifies logic of one of the functions and updates to use `id`.
- **Update `Meal`**: Removes the properties and updates methods. Further, `Meal.default()` now has a unique ID each time, so, in tests we have to make modifications to make sure we aren't getting wrong equality when `id` is different.
- **Update `Meal`s in all test files**: After changing the meal class, it was necessary to fix all broken meal constructions in the tests. In some cases, this means changing the ID from a `Long` to `String` and in other cases deleting it and letting it default to a random UUID.

## Questions for Reviewers

No Questions

## Future Work

- Remove `NutritionalInformation` from LocalDatabase column
- Purge Firebase to work with new serialization
- Use these `id`s to properly be able to edit meals.
