### PR TITLE
Account Settings

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/flow/SettingFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/flow/SettingFlowTest.kt
@@ -1,0 +1,71 @@
+package com.github.se.polyfit.ui.flow
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.data.User
+import com.github.se.polyfit.model.settings.SettingOption
+import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.ui.navigation.Route
+import com.github.se.polyfit.ui.screen.SettingScreen
+import com.github.se.polyfit.ui.screen.SettingsScreen
+import com.github.se.polyfit.ui.screen.settings.AccountSettingsScreen
+import com.github.se.polyfit.viewmodel.settings.AccountSettingsViewModel
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.every
+import io.mockk.junit4.MockKRule
+import io.mockk.mockk
+import kotlin.test.Test
+import org.junit.Before
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class SettingFlowTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule val mockkRule = MockKRule(this)
+
+  private val mockAccountSettingsViewModel: AccountSettingsViewModel = mockk(relaxed = true)
+
+  @Before
+  fun setup() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigation = Navigation(navController)
+      val options =
+          listOf(
+              SettingOption("Account", Icons.Default.Person, navigation::navigateToAccountSettings),
+          )
+      every { mockAccountSettingsViewModel.user.value } returns User(id = "test", email = "test")
+
+      NavHost(navController = navController, startDestination = Route.SettingsHome) {
+        composable(Route.SettingsHome) { SettingsScreen(settings = options) }
+
+        composable(Route.AccountSettings) {
+          AccountSettingsScreen(navigation::navigateToSettingsHome, mockAccountSettingsViewModel)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun settingScreenIsShown() {
+    ComposeScreen.onComposeScreen<SettingScreen>(composeTestRule) { title { assertIsDisplayed() } }
+  }
+
+  @Test
+  fun accountSettingsCanShow() {
+    ComposeScreen.onComposeScreen<SettingScreen>(composeTestRule) { settingItem { performClick() } }
+
+    ComposeScreen.onComposeScreen<AccountSettingsScreen>(composeTestRule) {
+      displayName { assertIsDisplayed() }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
@@ -46,6 +46,15 @@ class NavigationTest {
   }
 
   @Test
+  fun goBackTo() {
+    route = Route.Home
+    every { navHostController.popBackStack(route, any()) } returns true
+    navigation.goBackTo(Route.Home)
+
+    verify { navHostController.popBackStack(Route.Home, false) }
+  }
+
+  @Test
   fun navigateToAddMeal() {
     route = Route.AddMeal
     every { navHostController.navigate(route) } returns Unit

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/navigation/NavigationTest.kt
@@ -46,6 +46,24 @@ class NavigationTest {
   }
 
   @Test
+  fun navigateToCreatePost() {
+    route = Route.CreatePost
+    every { navHostController.navigate(route) } returns Unit
+    navigation.navigateToCreatePost()
+
+    verify { navHostController.navigate(Route.CreatePost) }
+  }
+
+  @Test
+  fun navigateToSettingsHome() {
+    route = Route.SettingsHome
+    every { navHostController.navigate(route) } returns Unit
+    navigation.navigateToSettingsHome()
+
+    verify { navHostController.navigate(Route.SettingsHome) }
+  }
+
+  @Test
   fun goBackTo() {
     route = Route.Home
     every { navHostController.popBackStack(route, any()) } returns true

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
@@ -1,0 +1,26 @@
+package com.github.se.polyfit.ui.screen.settings
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class AccountSettingsScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<AccountSettingsScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("AccountSettingsScreen") }) {
+
+  val displayName: KNode = child { hasTestTag("DisplayName") }
+  val firstName: KNode = child { hasTestTag("FirstName") }
+  val lastName: KNode = child { hasTestTag("LastName") }
+  val height: KNode = child { hasTestTag("Height") }
+  val weight: KNode = child { hasTestTag("Weight") }
+  val calorieGoal: KNode = child { hasTestTag("CalorieGoal") }
+}
+
+class AccountSettingsBottomBar(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<AccountSettingsBottomBar>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("BottomBarRow") }) {
+
+  val cancel: KNode = child { hasTestTag("Cancel") }
+  val save: KNode = child { hasTestTag("Save") }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsTest.kt
@@ -1,0 +1,129 @@
+package com.github.se.polyfit.ui.screen.settings
+
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.polyfit.model.data.User
+import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.viewmodel.settings.AccountSettingsViewModel
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.every
+import io.mockk.junit4.MockKRule
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDate
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AccountSettingsTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule val mockkRule = MockKRule(this)
+
+  private val mockNav: Navigation = mockk(relaxed = true)
+  private val mockViewModel: AccountSettingsViewModel = mockk(relaxed = true)
+
+  private val partialUser = User(id = "1", displayName = "John Doe", email = "")
+
+  private val baseUser =
+      User(
+          id = "1",
+          displayName = "John Doe",
+          givenName = "John",
+          familyName = "Doe",
+          email = "john@doe.com",
+          calorieGoal = 0)
+
+  val filledUser =
+      User(
+          id = "1",
+          displayName = "John Doe",
+          givenName = "John",
+          familyName = "Doe",
+          email = "john@doe.com",
+          heightCm = 180,
+          weightKg = 80.0,
+          calorieGoal = 2000,
+          dob = LocalDate.of(1990, 1, 2))
+
+  fun setup(user: User = baseUser) {
+    every { mockViewModel.user.value } returns user
+
+    composeTestRule.setContent { AccountSettingsScreen(mockNav::goBack, mockViewModel) }
+  }
+
+  @Test
+  fun fieldsPopulateIfExist() {
+    setup()
+
+    ComposeScreen.onComposeScreen<AccountSettingsScreen>(composeTestRule) {
+      displayName { assertTextContains("John Doe") }
+      firstName { assertTextContains("John") }
+      lastName { assertTextContains("Doe") }
+      height { assertTextContains("Height (cm)") }
+      weight { assertTextContains("Weight (kg)") }
+      calorieGoal { assertTextContains("Daily Calorie Goal (kCal)") }
+    }
+
+    ComposeScreen.onComposeScreen<AccountSettingsBottomBar>(composeTestRule) {
+      cancel {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+      save {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+    }
+  }
+
+  @Test
+  fun canNotSaveUnlessNameComplete() {
+    setup(partialUser)
+
+    ComposeScreen.onComposeScreen<AccountSettingsBottomBar>(composeTestRule) {
+      cancel {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+      save {
+        assertIsDisplayed()
+        assertIsNotEnabled()
+      }
+    }
+  }
+
+  @Test
+  fun allFieldsContainProperData() {
+    setup(filledUser)
+
+    ComposeScreen.onComposeScreen<AccountSettingsScreen>(composeTestRule) {
+      displayName { assertTextContains("John Doe") }
+      firstName { assertTextContains("John") }
+      lastName { assertTextContains("Doe") }
+      height { assertTextContains("180") }
+      weight { assertTextContains("80.0") }
+      calorieGoal {
+        assertTextContains("2000")
+
+        composeTestRule.onNodeWithTag("ChangeDateButton").assertTextContains("1990")
+        composeTestRule.onNodeWithTag("ChangeDateButton").assertTextContains("01")
+        composeTestRule.onNodeWithTag("ChangeDateButton").assertTextContains("01")
+      }
+    }
+  }
+
+  @Test
+  fun savingMakesCallToViewModel() {
+    setup()
+
+    ComposeScreen.onComposeScreen<AccountSettingsBottomBar>(composeTestRule) {
+      save { performClick() }
+    }
+
+    verify { mockViewModel.updateUser() }
+  }
+}

--- a/app/src/androidTest/java/com/github/se/polyfit/viewmodel/settings/AccountSettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/viewmodel/settings/AccountSettingsViewModelTest.kt
@@ -1,0 +1,133 @@
+package com.github.se.polyfit.viewmodel.settings
+
+import com.github.se.polyfit.data.remote.firebase.UserFirebaseRepository
+import com.github.se.polyfit.model.data.User
+import com.google.android.gms.tasks.Tasks
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDate
+import org.junit.Before
+import org.junit.Test
+
+class AccountSettingsViewModelTest {
+  private lateinit var viewModel: AccountSettingsViewModel
+  private val user = User("1", "Joe", "S", "Joe", "a@a")
+  private val mockUserFirebaseRepository = mockk<UserFirebaseRepository>(relaxed = true)
+
+  @Before
+  fun setup() {
+    viewModel = AccountSettingsViewModel(user, mockUserFirebaseRepository)
+  }
+
+  @Test
+  fun updateDisplayName() {
+    viewModel.updateDisplayName("Jay")
+    assert(viewModel.user.value.displayName == "Jay")
+  }
+
+  @Test
+  fun updateFirstName() {
+    viewModel.updateFirstName("Jay")
+    assert(viewModel.user.value.givenName == "Jay")
+  }
+
+  @Test
+  fun updateLastName() {
+    viewModel.updateLastName("Jay")
+    assert(viewModel.user.value.familyName == "Jay")
+  }
+
+  @Test
+  fun updateHeightWithValue() {
+    viewModel.updateHeight(180L)
+    assert(viewModel.user.value.heightCm == 180L)
+  }
+
+  @Test
+  fun updateHeightWithNull() {
+    viewModel.updateHeight(null)
+    assert(viewModel.user.value.heightCm == null)
+  }
+
+  @Test
+  fun updateWeightWithValue() {
+    viewModel.updateWeight(80.0)
+    assert(viewModel.user.value.weightKg == 80.0)
+  }
+
+  @Test
+  fun updateWeightWithNull() {
+    viewModel.updateWeight(null)
+    assert(viewModel.user.value.weightKg == null)
+  }
+
+  @Test
+  fun updateCalorieGoal() {
+    viewModel.updateCalorieGoal(2000L)
+    assert(viewModel.user.value.calorieGoal == 2000L)
+  }
+
+  @Test
+  fun updateDob() {
+    val date = LocalDate.of(2021, 1, 1)
+    viewModel.updateDob(date)
+    assert(viewModel.user.value.dob == date)
+  }
+
+  @Test
+  fun updateIsVegetarian() {
+    viewModel.updateIsVegetarian(true)
+    assert(viewModel.user.value.isVegetarian)
+  }
+
+  @Test
+  fun updateIsVegan() {
+    viewModel.updateIsVegan(true)
+    assert(viewModel.user.value.isVegan)
+  }
+
+  @Test
+  fun updateIsGlutenFree() {
+    viewModel.updateIsGlutenFree(true)
+    assert(viewModel.user.value.isGlutenFree)
+  }
+
+  @Test
+  fun updateIsLactoseFree() {
+    viewModel.updateIsLactoseFree(true)
+    assert(viewModel.user.value.isLactoseFree)
+  }
+
+  @Test
+  fun updateUserChangesInputAndCallsFirebase() {
+    coEvery { mockUserFirebaseRepository.storeUser(any()) } returns Tasks.forResult(null)
+
+    viewModel.updateDisplayName("Jay")
+    viewModel.updateFirstName("Jay")
+    viewModel.updateLastName("Jay")
+    viewModel.updateHeight(180L)
+    viewModel.updateWeight(80.0)
+    viewModel.updateCalorieGoal(2000L)
+    val date = LocalDate.of(2021, 1, 1)
+    viewModel.updateDob(date)
+    viewModel.updateIsVegetarian(true)
+    viewModel.updateIsVegan(true)
+    viewModel.updateIsGlutenFree(true)
+    viewModel.updateIsLactoseFree(true)
+    viewModel.updateUser()
+    assert(user.displayName == "Jay")
+    assert(user.givenName == "Jay")
+    assert(user.familyName == "Jay")
+    assert(user.heightCm == 180L)
+    assert(user.weightKg == 80.0)
+    assert(user.calorieGoal == 2000L)
+    assert(user.dob == date)
+    assert(user.isVegetarian)
+    assert(user.isVegan)
+    assert(user.isGlutenFree)
+    assert(user.isLactoseFree)
+
+    verify { mockUserFirebaseRepository.storeUser(viewModel.user.value) }
+  }
+}

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -74,7 +76,11 @@ class MainActivity : ComponentActivity() {
           }
 
           composable(Route.Settings) {
-            GenericScreen(navController = navController, content = { SettingFlow() })
+            GenericScreen(
+                navController = navController,
+                content = { paddingValues ->
+                  SettingFlow(modifier = Modifier.padding(paddingValues))
+                })
           }
 
           composable(Route.PostInfo) { PostInfoScreen(navigation, navController) }

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.github.se.polyfit.ui.components.GenericScreen
 import com.github.se.polyfit.ui.flow.AddMealFlow
+import com.github.se.polyfit.ui.flow.SettingFlow
 import com.github.se.polyfit.ui.navigation.Navigation
 import com.github.se.polyfit.ui.navigation.Route
 import com.github.se.polyfit.ui.screen.CreatePostScreen
@@ -70,6 +71,10 @@ class MainActivity : ComponentActivity() {
                 goBack = navigation::goBack,
                 goForward = { navigation.goBackTo(Route.DailyRecap) },
                 mealId = mealId)
+          }
+
+          composable(Route.Settings) {
+            GenericScreen(navController = navController, content = { SettingFlow() })
           }
 
           composable(Route.PostInfo) { PostInfoScreen(navigation, navController) }

--- a/app/src/main/java/com/github/se/polyfit/model/user/User.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/user/User.kt
@@ -2,6 +2,7 @@ package com.github.se.polyfit.model.data
 
 import android.net.Uri
 import android.util.Log
+import java.time.LocalDate
 
 data class User(
     var id: String = "",
@@ -9,23 +10,26 @@ data class User(
     var familyName: String? = null,
     var givenName: String? = null,
     var email: String = "",
-    var photoURL: Uri? = null
+    var photoURL: Uri? = null,
+    var heightCm: Long? = null,
+    var weightKg: Double? = null,
+    var dob: LocalDate? = null,
+    var calorieGoal: Long = 2200, // Not sure what we should have this default to
+    var isVegan: Boolean = false,
+    var isVegetarian: Boolean = false,
+    var isGlutenFree: Boolean = false,
+    var isLactoseFree: Boolean = false,
 ) {
 
   fun signOut() {
-    id = ""
-    displayName = null
-    familyName = null
-    givenName = null
-    email = ""
-    photoURL = null
+    update(User()) // Creates an empty user and then updates the current user with it
   }
 
   fun isSignedIn(): Boolean {
     return id.isNotEmpty()
   }
 
-  fun serialize(): Map<String, Any> {
+  fun serialize(): Map<String, Any?> {
     return serialize(this)
   }
 
@@ -36,7 +40,15 @@ data class User(
         familyName = user.familyName,
         givenName = user.givenName,
         email = user.email,
-        photoURL = user.photoURL)
+        photoURL = user.photoURL,
+        heightCm = user.heightCm,
+        weightKg = user.weightKg,
+        dob = user.dob,
+        calorieGoal = user.calorieGoal,
+        isVegan = user.isVegan,
+        isVegetarian = user.isVegetarian,
+        isGlutenFree = user.isGlutenFree,
+        isLactoseFree = user.isLactoseFree)
   }
 
   fun update(
@@ -45,7 +57,15 @@ data class User(
       familyName: String? = this.familyName,
       givenName: String? = this.givenName,
       email: String = this.email,
-      photoURL: Uri? = this.photoURL
+      photoURL: Uri? = this.photoURL,
+      heightCm: Long? = this.heightCm,
+      weightKg: Double? = this.weightKg,
+      dob: LocalDate? = this.dob,
+      calorieGoal: Long = this.calorieGoal,
+      isVegan: Boolean = this.isVegan,
+      isVegetarian: Boolean = this.isVegetarian,
+      isGlutenFree: Boolean = this.isGlutenFree,
+      isLactoseFree: Boolean = this.isLactoseFree
   ) {
     this.id = id
     this.displayName = displayName
@@ -53,29 +73,59 @@ data class User(
     this.givenName = givenName
     this.email = email
     this.photoURL = photoURL
+    this.heightCm = heightCm
+    this.weightKg = weightKg
+    this.dob = dob
+    this.calorieGoal = calorieGoal
+    this.isVegan = isVegan
+    this.isVegetarian = isVegetarian
+    this.isGlutenFree = isGlutenFree
+    this.isLactoseFree = isLactoseFree
   }
 
   companion object {
-    fun serialize(user: User): Map<String, Any> {
-      return mapOf(
-          "id" to user.id,
-          "displayName" to user.displayName!!,
-          "familyName" to user.familyName!!,
-          "givenName" to user.givenName!!,
-          "email" to user.email,
-          "photoURL" to user.photoURL.toString())
+    fun serialize(user: User): Map<String, Any?> {
+      Log.v("User", "Serializing user: $user")
+
+      // To serialize/store, they must have atleast id, email, and names.
+      val result =
+          mutableMapOf<String, Any?>(
+              "id" to user.id,
+              "displayName" to user.displayName!!,
+              "familyName" to user.familyName!!,
+              "givenName" to user.givenName!!,
+              "email" to user.email,
+              "calorieGoal" to user.calorieGoal,
+              "isVegan" to user.isVegan,
+              "isVegetarian" to user.isVegetarian,
+              "isGlutenFree" to user.isGlutenFree,
+              "isLactoseFree" to user.isLactoseFree)
+
+      user.photoURL?.let { result["photoURL"] = it.toString() }
+      user.heightCm?.let { result["heightCm"] = it }
+      user.weightKg?.let { result["weightKg"] = it }
+      user.dob?.let { result["dob"] = it.toString() }
+
+      return result
     }
 
     fun deserialize(map: Map<String, Any>): User {
       return try {
         User(
             id = map["id"] as String,
-            displayName = map["displayName"] as String,
-            familyName = map["familyName"] as String,
-            givenName = map["givenName"] as String,
+            displayName = map["displayName"] as? String,
+            familyName = map["familyName"] as? String,
+            givenName = map["givenName"] as? String,
             email = map["email"] as String,
-            photoURL =
-                if (map["photoURL"] != "null") Uri.parse(map["photoURL"] as String) else null)
+            photoURL = (map["photoURL"] as? String)?.let { Uri.parse(it) },
+            heightCm = map["heightCm"] as? Long,
+            weightKg = map["weightKg"] as? Double,
+            dob = (map["dob"] as? String)?.let { LocalDate.parse(it) },
+            calorieGoal = map["calorieGoal"] as? Long ?: 2200,
+            isVegan = map["isVegan"] as? Boolean ?: false,
+            isVegetarian = map["isVegetarian"] as? Boolean ?: false,
+            isGlutenFree = map["isGlutenFree"] as? Boolean ?: false,
+            isLactoseFree = map["isLactoseFree"] as? Boolean ?: false)
       } catch (e: Exception) {
         Log.e("User", "Error deserializing user", e)
         throw IllegalArgumentException("Error deserializing user : $e")
@@ -88,7 +138,15 @@ data class User(
           displayName = "Test User",
           familyName = "User",
           givenName = "Test",
-          email = "somethingsomething@google.ze")
+          email = "somethingsomething@google.ze",
+          heightCm = 180,
+          weightKg = 80.0,
+          dob = LocalDate.of(1990, 1, 1),
+          calorieGoal = 2200,
+          isVegan = false,
+          isVegetarian = false,
+          isGlutenFree = false,
+          isLactoseFree = false)
     }
   }
 }

--- a/app/src/main/java/com/github/se/polyfit/model/user/User.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/user/User.kt
@@ -85,8 +85,6 @@ data class User(
 
   companion object {
     fun serialize(user: User): Map<String, Any?> {
-      Log.v("User", "Serializing user: $user")
-
       // To serialize/store, they must have atleast id, email, and names.
       val result =
           mutableMapOf<String, Any?>(
@@ -109,7 +107,7 @@ data class User(
       return result
     }
 
-    fun deserialize(map: Map<String, Any>): User {
+    fun deserialize(map: Map<String, Any?>): User {
       return try {
         User(
             id = map["id"] as String,

--- a/app/src/main/java/com/github/se/polyfit/ui/components/GenericScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/GenericScreen.kt
@@ -1,8 +1,9 @@
 package com.github.se.polyfit.ui.components
 
 import android.content.Context
-import android.widget.Toast
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -10,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.github.se.polyfit.R
 import com.github.se.polyfit.ui.components.scaffold.AppTitle
 import com.github.se.polyfit.ui.components.scaffold.BottomNavigationBar
 import com.github.se.polyfit.ui.navigation.Route
@@ -33,19 +33,9 @@ fun GenericScreen(
             stackEntry,
             { navController.navigate(Route.Home) },
             { navController.navigate(Route.PostInfo) },
-            showToastMessage(context = context),
+            { navController.navigate(Route.Settings) },
             {})
-      },
-      content = content)
-}
-
-@Composable
-fun showToastMessage(context: Context): () -> Unit {
-  val toast =
-      Toast.makeText(
-          context,
-          context.getString(R.string.toast_message_feature_unavailable),
-          Toast.LENGTH_SHORT)
-
-  return { toast.show() }
+      }) {
+        Box(modifier = Modifier.padding(it)) { content(it) }
+      }
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/components/GenericScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/GenericScreen.kt
@@ -1,9 +1,7 @@
 package com.github.se.polyfit.ui.components
 
 import android.content.Context
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,6 +34,6 @@ fun GenericScreen(
             { navController.navigate(Route.Settings) },
             {})
       }) {
-        Box(modifier = Modifier.padding(it)) { content(it) }
+        content(it)
       }
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/components/GenericScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/GenericScreen.kt
@@ -1,12 +1,10 @@
 package com.github.se.polyfit.ui.components
 
-import android.content.Context
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.github.se.polyfit.ui.components.scaffold.AppTitle
@@ -20,7 +18,6 @@ fun GenericScreen(
     modifier: Modifier = Modifier,
     floatingButton: @Composable () -> Unit = {}
 ) {
-  val context: Context = LocalContext.current
   val stackEntry by navController.currentBackStackEntryAsState()
   Scaffold(
       modifier = modifier,
@@ -33,7 +30,6 @@ fun GenericScreen(
             { navController.navigate(Route.PostInfo) },
             { navController.navigate(Route.Settings) },
             {})
-      }) {
-        content(it)
-      }
+      },
+      content = content)
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/DateSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/DateSelector.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,12 +34,14 @@ import java.time.format.DateTimeFormatter
 fun DateSelector(
     onConfirm: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
-    title: String = ""
+    title: String = "",
+    inputDate: LocalDate? = null,
+    titleStyle: TextStyle = MaterialTheme.typography.titleLarge,
 ) {
   var showDatePicker by remember { mutableStateOf(false) }
 
-  // I'm *pretty sure* this should select the right time and zone, but if test flakes this is why
-  val initialMillis = LocalDate.now(ZoneId.systemDefault()).toEpochDay() * 1000 * 60 * 60 * 24
+  val startDate = inputDate ?: LocalDate.now(ZoneId.systemDefault())
+  val initialMillis = startDate.toEpochDay() * 1000 * 60 * 60 * 24
   val datePickerState = rememberDatePickerState(initialSelectedDateMillis = initialMillis)
 
   val selectedDate =
@@ -53,7 +56,7 @@ fun DateSelector(
     if (title.isNotEmpty()) {
       Text(
           text = title,
-          style = MaterialTheme.typography.titleLarge,
+          style = titleStyle,
           color = PurpleGrey40,
           modifier = Modifier.padding(16.dp, 0.dp).testTag("Title"))
     }

--- a/app/src/main/java/com/github/se/polyfit/ui/flow/SettingFlow.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/flow/SettingFlow.kt
@@ -3,6 +3,7 @@ package com.github.se.polyfit.ui.flow
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -13,7 +14,7 @@ import com.github.se.polyfit.ui.screen.SettingsScreen
 import com.github.se.polyfit.ui.screen.settings.AccountSettingsScreen
 
 @Composable
-fun SettingFlow() {
+fun SettingFlow(modifier: Modifier = Modifier) {
   val navController = rememberNavController()
   val navigation = Navigation(navController)
   val options =
@@ -21,9 +22,12 @@ fun SettingFlow() {
           SettingOption("Account", Icons.Default.Person, navigation::navigateToAccountSettings),
       )
 
-  NavHost(navController = navController, startDestination = Route.SettingsHome) {
-    composable(Route.SettingsHome) { SettingsScreen(settings = options) }
+  NavHost(
+      navController = navController, startDestination = Route.SettingsHome, modifier = modifier) {
+        composable(Route.SettingsHome) { SettingsScreen(settings = options) }
 
-    composable(Route.AccountSettings) { AccountSettingsScreen(navigation::navigateToSettingsHome) }
-  }
+        composable(Route.AccountSettings) {
+          AccountSettingsScreen(navigation::navigateToSettingsHome)
+        }
+      }
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/flow/SettingFlow.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/flow/SettingFlow.kt
@@ -1,0 +1,29 @@
+package com.github.se.polyfit.ui.flow
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.github.se.polyfit.model.settings.SettingOption
+import com.github.se.polyfit.ui.navigation.Navigation
+import com.github.se.polyfit.ui.navigation.Route
+import com.github.se.polyfit.ui.screen.SettingsScreen
+import com.github.se.polyfit.ui.screen.settings.AccountSettingsScreen
+
+@Composable
+fun SettingFlow() {
+  val navController = rememberNavController()
+  val navigation = Navigation(navController)
+  val options =
+      listOf(
+          SettingOption("Account", Icons.Default.Person, navigation::navigateToAccountSettings),
+      )
+
+  NavHost(navController = navController, startDestination = Route.SettingsHome) {
+    composable(Route.SettingsHome) { SettingsScreen(settings = options) }
+
+    composable(Route.AccountSettings) { AccountSettingsScreen(navigation::navigateToSettingsHome) }
+  }
+}

--- a/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/navigation/Navigation.kt
@@ -52,6 +52,14 @@ class Navigation(private val navHostController: NavHostController) {
     navigateTo(Route.CreatePost)
   }
 
+  fun navigateToSettingsHome() {
+    navigateTo(Route.SettingsHome)
+  }
+
+  fun navigateToAccountSettings() {
+    navigateTo(Route.AccountSettings)
+  }
+
   private fun navigateTo(route: String) {
     Log.i("Navigation", "Navigating to $route")
     navHostController.navigate(route)

--- a/app/src/main/java/com/github/se/polyfit/ui/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/navigation/Route.kt
@@ -7,6 +7,8 @@ object Route {
   const val Overview = "Overview"
   const val Map = "Map"
   const val Settings = "Settings"
+  const val SettingsHome = "SettingsHome"
+  const val AccountSettings = "AccountSettings"
 
   const val DailyRecap = "DailyRecap"
   const val AddMeal = "AddMeal"

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
@@ -1,0 +1,200 @@
+package com.github.se.polyfit.ui.screen.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat.getString
+import androidx.hilt.navigation.compose.hiltViewModel
+import co.yml.charts.common.extensions.isNotNull
+import com.github.se.polyfit.R
+import com.github.se.polyfit.ui.components.scaffold.SimpleTopBar
+import com.github.se.polyfit.ui.components.selector.DateSelector
+import com.github.se.polyfit.ui.theme.PrimaryPurple
+import com.github.se.polyfit.ui.theme.PurpleGrey40
+import com.github.se.polyfit.viewmodel.settings.AccountSettingsViewModel
+
+@Composable
+fun AccountSettingsScreen(
+    goBack: () -> Unit,
+    accountSettingsViewModel: AccountSettingsViewModel = hiltViewModel()
+) {
+  val context = LocalContext.current
+  val user = accountSettingsViewModel.user.collectAsState().value
+  val canSave =
+      !user.givenName.isNullOrEmpty() &&
+          !user.familyName.isNullOrEmpty() &&
+          !user.displayName.isNullOrEmpty()
+
+  Scaffold(
+      topBar = { SimpleTopBar(getString(context, R.string.accountSettings), goBack) },
+      bottomBar = {
+        BottomBar(
+            onSave = {
+              accountSettingsViewModel.updateUser()
+              goBack()
+            },
+            canSave = canSave,
+            onCancel = goBack)
+      }) {
+        AccountSettings(accountSettingsViewModel, modifier = Modifier.padding(it))
+      }
+}
+
+@Composable
+private fun AccountSettings(
+    accountSettingsViewModel: AccountSettingsViewModel,
+    modifier: Modifier = Modifier,
+) {
+  val context = LocalContext.current
+  val user = accountSettingsViewModel.user.collectAsState().value
+
+  var height by remember { mutableStateOf(user.heightCm?.toString() ?: "") }
+  var weight by remember { mutableStateOf(user.weightKg?.toString() ?: "") }
+  var calorieGoal by remember {
+    mutableStateOf(if (user.calorieGoal > 0) user.calorieGoal.toString() else "")
+  }
+
+  Column(modifier = modifier.padding(horizontal = 16.dp).testTag("AccountSettingsScreen")) {
+    TextField(
+        value = user.displayName ?: "",
+        placeholder = { Text(getString(context, R.string.accountSettingsDisplayName)) },
+        label = { Text(getString(context, R.string.accountSettingsDisplayName)) },
+        onValueChange = accountSettingsViewModel::updateDisplayName,
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("DisplayName"))
+    TextField(
+        value = user.givenName ?: "",
+        placeholder = { Text(getString(context, R.string.accountSettingsFirstName)) },
+        label = { Text(getString(context, R.string.accountSettingsFirstName)) },
+        onValueChange = accountSettingsViewModel::updateFirstName,
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("FirstName"))
+    TextField(
+        value = user.familyName ?: "",
+        placeholder = { Text(getString(context, R.string.accountSettingsLastName)) },
+        label = { Text(getString(context, R.string.accountSettingsLastName)) },
+        onValueChange = accountSettingsViewModel::updateLastName,
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("LastName"))
+    TextField(
+        value = height,
+        placeholder = { Text(getString(context, R.string.accountSettingsHeight)) },
+        label = { Text(getString(context, R.string.accountSettingsHeight)) },
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        onValueChange = {
+          val update = it.toLongOrNull()
+          height =
+              when {
+                update == null || update <= 0 -> ""
+                else -> update.toString()
+              }
+          accountSettingsViewModel.updateHeight(
+              when {
+                update.isNotNull() && update!! > 0 -> update
+                else -> null
+              })
+        },
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("Height"))
+    TextField(
+        value = weight,
+        placeholder = { Text(getString(context, R.string.accountSettingsWeight)) },
+        label = { Text(getString(context, R.string.accountSettingsWeight)) },
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        onValueChange = {
+          val update = it.toDoubleOrNull()
+          weight =
+              when {
+                update.isNotNull() && update!! <= 0 -> ""
+                update.isNotNull() -> update.toString()
+                else -> weight
+              }
+          accountSettingsViewModel.updateWeight(
+              when {
+                update.isNotNull() && update!! > 0 -> update
+                else -> null
+              })
+        },
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("Weight"))
+    TextField(
+        value = calorieGoal,
+        placeholder = { Text(getString(context, R.string.accountSettingsCalorieGoal)) },
+        label = { Text(getString(context, R.string.accountSettingsCalorieGoal)) },
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        onValueChange = {
+          val update = it.toLongOrNull()
+          calorieGoal =
+              when {
+                update == null || update <= 0 -> ""
+                else -> update.toString()
+              }
+          accountSettingsViewModel.updateCalorieGoal(update ?: 0)
+        },
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("CalorieGoal"))
+
+    DateSelector(
+        onConfirm = accountSettingsViewModel::updateDob,
+        title = getString(context, R.string.accountSettingsDob),
+        titleStyle = MaterialTheme.typography.titleMedium,
+        inputDate = user.dob,
+        modifier = Modifier.padding(vertical = 8.dp))
+
+    // TODO: Add interface to set dietary preferences
+  }
+}
+
+@Composable
+private fun BottomBar(onSave: () -> Unit, canSave: Boolean, onCancel: () -> Unit) {
+  val context = LocalContext.current
+
+  BottomAppBar(containerColor = Color.Transparent) {
+    Row(
+        modifier = Modifier.fillMaxWidth().testTag("BottomBarRow"),
+        horizontalArrangement = Arrangement.End) {
+          TextButton(
+              modifier = Modifier.testTag("Cancel"),
+              colors = ButtonDefaults.textButtonColors(contentColor = PurpleGrey40),
+              onClick = onCancel) {
+                Text(getString(context, R.string.accountSettingsCancel))
+              }
+          TextButton(
+              modifier = Modifier.testTag("Save"),
+              colors = ButtonDefaults.textButtonColors(contentColor = PrimaryPurple),
+              enabled = canSave,
+              onClick = onSave) {
+                Text(getString(context, R.string.accountSettingsSave))
+              }
+        }
+  }
+}
+
+@Preview
+@Composable
+fun AccountSettingsScreenPreview() {
+  AccountSettingsScreen(goBack = {})
+}

--- a/app/src/main/java/com/github/se/polyfit/viewmodel/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/github/se/polyfit/viewmodel/settings/AccountSettingsViewModel.kt
@@ -1,0 +1,76 @@
+package com.github.se.polyfit.viewmodel.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.se.polyfit.data.remote.firebase.UserFirebaseRepository
+import com.github.se.polyfit.model.data.User
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class AccountSettingsViewModel
+@Inject
+constructor(
+    private val currentUser: User,
+    private val userFirebaseRepository: UserFirebaseRepository
+) : ViewModel() {
+  private val _user = MutableStateFlow(currentUser)
+  val user: StateFlow<User> = _user
+
+  fun updateDisplayName(name: String) {
+    _user.value = _user.value.copy(displayName = name)
+  }
+
+  fun updateFirstName(name: String) {
+    _user.value = _user.value.copy(givenName = name)
+  }
+
+  fun updateLastName(name: String) {
+    _user.value = _user.value.copy(familyName = name)
+  }
+
+  fun updateHeight(height: Long?) {
+    _user.value = _user.value.copy(heightCm = height)
+  }
+
+  fun updateWeight(weight: Double?) {
+    _user.value = _user.value.copy(weightKg = weight)
+  }
+
+  fun updateCalorieGoal(calorieGoal: Long) {
+    _user.value = _user.value.copy(calorieGoal = calorieGoal)
+  }
+
+  fun updateDob(date: LocalDate) {
+    _user.value = _user.value.copy(dob = date)
+  }
+
+  fun updateIsVegetarian(isVegetarian: Boolean) {
+    _user.value = _user.value.copy(isVegetarian = isVegetarian)
+  }
+
+  fun updateIsVegan(isVegan: Boolean) {
+    _user.value = _user.value.copy(isVegan = isVegan)
+  }
+
+  fun updateIsGlutenFree(isGlutenFree: Boolean) {
+    _user.value = _user.value.copy(isGlutenFree = isGlutenFree)
+  }
+
+  fun updateIsLactoseFree(isLactoseFree: Boolean) {
+    _user.value = _user.value.copy(isLactoseFree = isLactoseFree)
+  }
+
+  fun updateUser() {
+    viewModelScope.launch {
+      withContext(Dispatchers.IO) { userFirebaseRepository.storeUser(_user.value) }
+    }
+    currentUser.update(_user.value)
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="dialog_headline">Choose Option</string>
     <string name="home_nav_label">Home</string>
     <string name="map_nav_posts">Posts</string>
-
     <string name="map_nav_label">Map</string>
     <string name="settings">Settings</string>
     <string name="toast_message_feature_unavailable">Not available yet</string>
@@ -43,4 +42,14 @@
     <string name="PermissionDenied">Permission denied</string>
     <string name="TakeToTakePicture">Tap to take a photo</string>
     <string name="CreatePostImageDesription">Captured image</string>
+    <string name="accountSettings">Account Information</string>
+    <string name="accountSettingsCancel">Cancel</string>
+    <string name="accountSettingsSave">Save</string>
+    <string name="accountSettingsDob">Date of Birth</string>
+    <string name="accountSettingsCalorieGoal">Daily Calorie Goal (kCal)</string>
+    <string name="accountSettingsWeight">Weight (kg)</string>
+    <string name="accountSettingsHeight">Height (cm)</string>
+    <string name="accountSettingsLastName">Last Name</string>
+    <string name="accountSettingsFirstName">First Name</string>
+    <string name="accountSettingsDisplayName">Display Name</string>
 </resources>

--- a/app/src/test/java/com/github/se/polyfit/data/user/UserTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/data/user/UserTest.kt
@@ -67,7 +67,7 @@ class UserTest {
     assertEquals("Test", map["familyName"])
     assertEquals("User", map["givenName"])
     assertEquals(" invalid email", map["email"])
-    assertEquals("null", map["photoURL"])
+    assertEquals(null, map["photoURL"])
   }
 
   @Test
@@ -79,7 +79,7 @@ class UserTest {
     assertEquals("Test", map["familyName"])
     assertEquals("User", map["givenName"])
     assertEquals(" invalid email", map["email"])
-    assertEquals("null", map["photoURL"])
+    assertEquals(null, map["photoURL"])
   }
 
   @Test
@@ -127,14 +127,22 @@ class UserTest {
   }
 
   @Test
-  fun `User deserialization with invalid map`() {
+  fun `User deserialization with missing ID`() {
+    // Invalid if no email or ID
     val map =
         mapOf(
-            "id" to "null",
             "familyName" to "Test",
             "givenName" to "User",
             "email" to " invalid email",
             "photoURL" to "null")
+    assertFailsWith<Exception> { User.deserialize(map) }
+  }
+
+  @Test
+  fun `User deserialization with missing email`() {
+    // Invalid if no email or ID
+    val map =
+        mapOf("id" to "1", "familyName" to "Test", "givenName" to "User", "photoURL" to "null")
     assertFailsWith<Exception> { User.deserialize(map) }
   }
 


### PR DESCRIPTION
UI, Viewmodel, tests for Account Settings. It is fully integrated with backend.

On this screen, Users can edit the information we have about them. The name fields are mandatory, and the rest is optional (since this stuff needs to be edited by the user because we don't get it from firebase). It is integrated with the bottom navigation bar and the main setting screen.

I haven't yet added the UI/sliders for the dietary restrictions because of time constraint, but I think this will be sufficient for M3 and then will add those in M4. The backend is setup for them already

<img width="150" alt="Screenshot 2024-05-16 at 1 18 58 PM" src="https://github.com/swent-group10/polyfit/assets/72662164/25a0c2d4-2603-4ef9-8745-6e34367179de">
