### PR TITLE
Prevent PrimaryButton double clicks

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/button/PrimaryButtonTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/button/PrimaryButtonTest.kt
@@ -11,14 +11,14 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.polyfit.ui.components.GradientBox
-import com.github.se.polyfit.ui.navigation.Navigation
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -30,8 +30,6 @@ class PrimaryButtonTest : TestCase() {
   @get:Rule val composeTestRule = createComposeRule()
 
   @get:Rule val mockkRule = MockKRule(this)
-
-  @RelaxedMockK lateinit var mockNav: Navigation
 
   @Before
   fun setup() {
@@ -78,5 +76,25 @@ class PrimaryButtonTest : TestCase() {
       verify { Log.v("Button", "Clicked") }
       composeTestRule.onNodeWithText("Hello World").assertIsDisplayed()
     }
+  }
+
+  @Test
+  fun onClickOnlyWorksOnce() = runTest {
+    val onClick = mockk<() -> Unit>(relaxed = true)
+
+    composeTestRule.setContent {
+      PrimaryButton(
+          onClick = onClick,
+          text = "Hello World",
+      )
+    }
+    ComposeScreen.onComposeScreen<GradientBox>(composeTestRule) {
+      composeTestRule.onNodeWithTag("PrimaryButton").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("PrimaryButton").assertHasClickAction()
+      composeTestRule.onNodeWithTag("PrimaryButton").performClick()
+      composeTestRule.onNodeWithTag("PrimaryButton").performClick()
+    }
+
+    verify(exactly = 1) { onClick() }
   }
 }

--- a/app/src/main/java/com/github/se/polyfit/ui/components/button/PrimaryButton.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/button/PrimaryButton.kt
@@ -34,8 +34,8 @@ fun PrimaryButton(
   Button(
       onClick = {
         if (!pressed) {
-          onClick()
           pressed = true
+          onClick()
         }
       },
       enabled = isEnabled,

--- a/app/src/main/java/com/github/se/polyfit/ui/components/button/PrimaryButton.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/button/PrimaryButton.kt
@@ -6,6 +6,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -25,8 +29,15 @@ fun PrimaryButton(
     buttonShape: RoundedCornerShape = RoundedCornerShape(50.dp),
     icon: @Composable (() -> Unit)? = null
 ) {
+  var pressed by remember { mutableStateOf(false) }
+
   Button(
-      onClick = onClick,
+      onClick = {
+        if (!pressed) {
+          onClick()
+          pressed = true
+        }
+      },
       enabled = isEnabled,
       modifier = modifier.testTag("PrimaryButton"),
       shape = buttonShape,


### PR DESCRIPTION
Only run the onClick of the primary button once, to prevent unexpected side-effects of spam