### PR TITLE
Fix issues with editing ingredient info

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/ingredients/IngredientNutritionEditFieldsTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/ingredients/IngredientNutritionEditFieldsTest.kt
@@ -83,7 +83,6 @@ class IngredientNutritionEditFieldsTest : TestCase() {
         assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        performImeAction()
         assertTextContains("1.0")
       }
       caloriesInput {
@@ -91,14 +90,13 @@ class IngredientNutritionEditFieldsTest : TestCase() {
         assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        assertTextContains("1")
+        assertTextContains("1.0")
       }
       carbsInput {
         assertIsDisplayed()
         assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        performImeAction()
         assertTextContains("1.0")
       }
       caloriesInput { assertTextContains("1.0") }
@@ -107,7 +105,6 @@ class IngredientNutritionEditFieldsTest : TestCase() {
         assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        performImeAction()
         assertTextContains("1.0")
       }
       proteinInput {
@@ -115,7 +112,6 @@ class IngredientNutritionEditFieldsTest : TestCase() {
         assertTextContains("0.0")
         performTextClearance()
         performTextInput("1")
-        performImeAction()
         assertTextContains("1.0")
       }
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
@@ -3,7 +3,6 @@ package com.github.se.polyfit.ui.flow
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/flow/AddMealFlowTest.kt
@@ -82,7 +82,6 @@ class AddMealFlowTest {
       composeTestRule.onNodeWithText("Enter an Ingredient...").performTextInput("apple")
       composeTestRule.onNodeWithTag("NutritionSizeInput Calories").performTextInput("1")
       composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performTextInput("1")
-      composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performImeAction()
       finishAddIngredientButton { performClick() }
     }
 
@@ -107,7 +106,6 @@ class AddMealFlowTest {
       composeTestRule.onNodeWithText("Enter an Ingredient...").performTextInput("apple")
       composeTestRule.onNodeWithTag("NutritionSizeInput Calories").performTextInput("1")
       composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performTextInput("1")
-      composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performImeAction()
       finishAddIngredientButton { performClick() }
     }
 

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/IngredientTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.polyfit.data.repository.MealRepository
@@ -170,8 +169,6 @@ class IngredientTest : TestCase() {
       composeTestRule.onNodeWithTag("NutritionSizeInput Calories").performTextInput("1")
 
       composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performTextInput("1")
-
-      composeTestRule.onNodeWithTag("NutritionSizeInput Total Weight").performImeAction()
 
       finishAddIngredientButton {
         assertIsDisplayed()

--- a/app/src/main/java/com/github/se/polyfit/ui/components/ingredients/IngredientNutritionEditFields.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/ingredients/IngredientNutritionEditFields.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -20,14 +19,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import co.yml.charts.common.extensions.isNotNull
 import com.github.se.polyfit.model.nutritionalInformation.Nutrient
 import com.github.se.polyfit.ui.theme.PrimaryPurple
 import com.github.se.polyfit.ui.theme.SecondaryGrey
@@ -40,11 +38,11 @@ fun IngredientNutritionEditFields(
 ) {
 
   // TODO: add a way to enter more fields/type of nutritents
-
   LazyColumn(modifier = modifier.testTag("NutritionInfoContainer")) {
     itemsIndexed(nutritionFields) { index, nutrient ->
-      var isFocused by remember { mutableStateOf(false) }
-      var text by remember { mutableStateOf(nutrient.amount.toString()) }
+      var text by remember {
+        mutableStateOf(if (nutrient.amount > 0.0) nutrient.amount.toString() else "")
+      }
       Row(
           verticalAlignment = Alignment.CenterVertically,
           modifier =
@@ -59,32 +57,23 @@ fun IngredientNutritionEditFields(
                     Modifier.testTag("NutritionLabel " + nutrient.getFormattedName()).weight(1.5f))
 
             TextField(
-                keyboardOptions =
-                    KeyboardOptions(
-                        keyboardType = KeyboardType.Decimal,
-                        imeAction = ImeAction.Done,
-                    ),
-                keyboardActions =
-                    KeyboardActions(
-                        onDone = {
-                          text =
-                              formatText(index, nutritionFields, nutrient, text) { newText ->
-                                text = newText
-                              }
-                        }),
                 value = text,
-                onValueChange = { newValue -> text = newValue },
+                placeholder = { Text(text = "0.0") },
+                keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+                singleLine = true,
+                onValueChange = {
+                  val update = it.toDoubleOrNull()
+                  text =
+                      when {
+                        update.isNotNull() && update!! <= 0 -> ""
+                        update.isNotNull() -> update.toString()
+                        else -> text
+                      }
+                  updateNutrient(index, nutritionFields, nutrient, text)
+                },
                 modifier =
                     Modifier.testTag("NutritionSizeInput " + nutrient.getFormattedName())
-                        .weight(0.5f)
-                        .onFocusChanged { focusState ->
-                          isFocused = focusState.isFocused
-                          handleFocusChange(isFocused, index, nutritionFields, nutrient, text) {
-                              newText ->
-                            text = newText
-                          }
-                        },
-                singleLine = true,
+                        .weight(0.5f),
                 colors =
                     TextFieldDefaults.colors(
                         focusedIndicatorColor = PrimaryPurple,
@@ -107,35 +96,17 @@ fun IngredientNutritionEditFields(
   }
 }
 
-private fun formatText(
+private fun updateNutrient(
     index: Int,
     nutritionFields: MutableList<Nutrient>,
     nutrient: Nutrient,
     text: String,
-    updateText: (String) -> Unit
-): String {
-  var newText = text
+) {
+  var newText = text.ifEmpty { "0.0" }
   try {
     newText = removeLeadingZerosAndNonDigits(newText)
     nutritionFields[index] = nutrient.copy(amount = newText.toDouble())
-    newText = newText.toDouble().toString()
   } catch (_: NumberFormatException) {
     Log.w("Catch Exception", "Text formatting gone wrong")
-  }
-
-  updateText(newText)
-  return newText
-}
-
-private fun handleFocusChange(
-    isFocused: Boolean,
-    index: Int,
-    nutritionFields: MutableList<Nutrient>,
-    nutrient: Nutrient,
-    text: String,
-    updateText: (String) -> Unit
-) {
-  if (!isFocused) { // Check if the TextField has lost focus
-    formatText(index, nutritionFields, nutrient, text, updateText)
   }
 }


### PR DESCRIPTION
Now, when you type `1` it will say `1.0` instead of `10.0`. Also, as soon as you type it, the button will activate.