### PR TITLE
Show a helpful message when posting if there are no meals

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
@@ -105,7 +105,7 @@ class MealSelectorTest : TestCase() {
       mealSelectorRow {
         assertIsDisplayed()
         assertTextContains("eggs")
-        assertTextContains("1.0 kcal")
+        assertTextContains("1.0 kCal")
       }
 
       carbs { assertIsDisplayed() }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreateAPostScreen.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/CreateAPostScreen.kt
@@ -14,6 +14,14 @@ class CreatePostScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val mealSelector: KNode = child { hasTestTag("MealSelector") }
 }
 
+class CreatePostAddMeal(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<CreatePostAddMeal>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("CreateMeal") }) {
+
+  val noMealsFound: KNode = child { hasTestTag("NoMealsFound") }
+  val addMealButton: KNode = child { hasTestTag("AddMealButton") }
+}
+
 class CreatePostTopBar(semanticsProvider: SemanticsNodeInteractionsProvider) :
     ComposeScreen<CreatePostTopBar>(
         semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("TopBar") }) {

--- a/app/src/main/java/com/github/se/polyfit/MainActivity.kt
+++ b/app/src/main/java/com/github/se/polyfit/MainActivity.kt
@@ -86,7 +86,8 @@ class MainActivity : ComponentActivity() {
           composable(Route.PostInfo) { PostInfoScreen(navigation, navController) }
 
           composable(Route.CreatePost) {
-            CreatePostScreen(navigation::goBack, navigation::navigateToHome)
+            CreatePostScreen(
+                navigation::goBack, navigation::navigateToHome, navigation::navigateToAddMeal)
           }
 
           composable(Route.DailyRecap) {

--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
@@ -82,7 +82,10 @@ fun MealSelector(
                   modifier = Modifier.weight(1f),
               )
               Text(
-                  text = "${selectedMeal.calculateTotalCalories().roundTwoDecimal()} kcal",
+                  text =
+                      context.getString(
+                          R.string.kcalvalue,
+                          selectedMeal.calculateTotalCalories().roundTwoDecimal()),
                   fontSize = 20.sp,
                   modifier = Modifier.weight(1f).padding(end = 20.dp),
                   textAlign = TextAlign.End,

--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
@@ -82,7 +82,7 @@ fun MealSelector(
                   modifier = Modifier.weight(1f),
               )
               Text(
-                  text = "${selectedMeal.calculateTotalCalories()} kcal",
+                  text = "${selectedMeal.calculateTotalCalories().roundTwoDecimal()} kcal",
                   fontSize = 20.sp,
                   modifier = Modifier.weight(1f).padding(end = 20.dp),
                   textAlign = TextAlign.End,

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/CreatePostScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/CreatePostScreen.kt
@@ -2,8 +2,10 @@ package com.github.se.polyfit.ui.screen
 
 import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -51,6 +53,7 @@ import com.google.android.gms.location.CurrentLocationRequest
 fun CreatePostScreen(
     navigateBack: () -> Unit = {},
     navigateForward: () -> Unit = {},
+    navigateToAddMeal: () -> Unit = {},
     postViewModel: CreatePostViewModel = hiltViewModel()
 ) {
   val context = LocalContext.current
@@ -78,6 +81,11 @@ fun CreatePostScreen(
         BottomBar(
             postComplete = postComplete, onButtonPressed = { isPermissionDialogDisplay = true })
       }) {
+        if (meals.isEmpty()) {
+          CreateMeal(navigateToAddMeal, Modifier.padding(it))
+          return@Scaffold
+        }
+
         LazyColumn(modifier = Modifier.padding(it).testTag("CreatePostScreen")) {
           item {
             PictureSelector(
@@ -94,6 +102,27 @@ fun CreatePostScreen(
           LocationPermissionDialog(
               onApprove = ::onApprove, onDeny = { isPermissionDialogDisplay = false })
         }
+      }
+}
+
+@Composable
+private fun CreateMeal(navigateToAddMeal: () -> Unit, modifier: Modifier = Modifier) {
+  val context = LocalContext.current
+  Column(
+      modifier = modifier.fillMaxSize().testTag("CreateMeal"),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = context.getString(R.string.noMealsFound),
+            color = SecondaryGrey,
+            fontSize = 20.sp,
+            modifier = Modifier.padding(top = 16.dp, bottom = 8.dp).testTag("NoMealsFound"))
+        PrimaryButton(
+            text = context.getString(R.string.addMealButton),
+            onClick = navigateToAddMeal,
+            color = PrimaryPink,
+            fontSize = 24,
+            modifier = Modifier.padding(bottom = 16.dp).testTag("AddMealButton"))
       }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,4 +60,6 @@
     <string name="accountSettingsLastName">Last Name</string>
     <string name="accountSettingsFirstName">First Name</string>
     <string name="accountSettingsDisplayName">Display Name</string>
+    <string name="noMealsFound">No recorded meals</string>
+    <string name="addMealButton">Add a Meal</string>
 </resources>


### PR DESCRIPTION
When making a post, if you have no meals it will bring you to the create post screen and you won't be able to select anything. Instead, let's show a helpful message that directs users to add a meal. Also small fix is to round the calories to two decimals to fix formatting display issue

<img width="200" alt="image" src="https://github.com/swent-group10/polyfit/assets/72662164/5d2fb079-3d4d-40a0-8e4f-e76956bb6e51">
