### PR TITLE
bugfix, bumping the display of graph elements to 2 decimal points

### DIFF
--- a/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/components/selector/MealSelectorTest.kt
@@ -105,7 +105,7 @@ class MealSelectorTest : TestCase() {
       mealSelectorRow {
         assertIsDisplayed()
         assertTextContains("eggs")
-        assertTextContains("1.0 kCal")
+        assertTextContains("1.00 kCal")
       }
 
       carbs { assertIsDisplayed() }

--- a/app/src/androidTest/java/com/github/se/polyfit/ui/screen/GraphScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/polyfit/ui/screen/GraphScreenTest.kt
@@ -145,13 +145,13 @@ class GraphScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     val nodes = composeTestRule.onAllNodesWithTag("kcal")
     val sortedData =
         listOf(
-            "870.2 kCal",
-            "1000.0 kCal",
-            "1000.0 kCal",
-            "1300.0 kCal",
-            "1689.9 kCal",
-            "2399.3 kCal",
-            "2438.0 kCal")
+            "870.20 kCal",
+            "1000.00 kCal",
+            "1000.00 kCal",
+            "1300.00 kCal",
+            "1689.90 kCal",
+            "2399.30 kCal",
+            "2438.00 kCal")
     nodes.assertCountEquals(sortedData.size)
     sortedData.forEachIndexed { index, kcal ->
       nodes[index].assertTextContains(kcal, ignoreCase = true)
@@ -169,13 +169,13 @@ class GraphScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     val nodes = composeTestRule.onAllNodesWithTag("kcal")
     val sortedData =
         listOf(
-            "2438.0 kCal",
-            "2399.3 kCal",
-            "1689.9 kCal",
-            "1300.0 kCal",
-            "1000.0 kCal",
-            "1000.0 kCal",
-            "870.2 kCal")
+            "2438.00 kCal",
+            "2399.30 kCal",
+            "1689.90 kCal",
+            "1300.00 kCal",
+            "1000.00 kCal",
+            "1000.00 kCal",
+            "870.20 kCal")
     nodes.assertCountEquals(sortedData.size)
     sortedData.forEachIndexed { index, kcal ->
       nodes[index].assertTextContains(kcal, ignoreCase = true)
@@ -197,7 +197,8 @@ class GraphScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     composeTestRule.waitForIdle()
 
     val nodes = composeTestRule.onAllNodesWithTag("weight")
-    val sortedWeight = listOf("35.0 g", "45.0 g", "65.9 g", "78.0 g", "78.0 g", "80.2 g", "330.0 g")
+    val sortedWeight =
+        listOf("35.00 g", "45.00 g", "65.90 g", "78.00 g", "78.00 g", "80.20 g", "330.00 g")
     nodes.assertCountEquals(sortedWeight.size)
     sortedWeight.forEachIndexed { index, weight ->
       nodes[index].assertTextContains(weight, ignoreCase = true)
@@ -221,7 +222,7 @@ class GraphScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
 
     val nodes = composeTestRule.onAllNodesWithTag("weight")
     val sortedWeightsDescending =
-        listOf("330.0 g", "80.2 g", "78.0 g", "78.0 g", "65.9 g", "45.0 g", "35.0 g")
+        listOf("330.00 g", "80.20 g", "78.00 g", "78.00 g", "65.90 g", "45.00 g", "35.00 g")
     nodes.assertCountEquals(sortedWeightsDescending.size)
     sortedWeightsDescending.forEachIndexed { index, weight ->
       nodes[index].assertTextContains(weight, ignoreCase = true)
@@ -421,7 +422,7 @@ class GraphScreenTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     composeTestRule.waitForIdle()
     // Assert only the matching GraphData elements are displayed
     composeTestRule
-        .onAllNodesWithText("1000.0 kCal", ignoreCase = true)
+        .onAllNodesWithText("1000.00 kCal", ignoreCase = true)
         .assertCountEquals(2) // Assuming two entries match this
 
     composeTestRule.onNodeWithTag("GraphScreenSearchBar").performTextInput("5000")

--- a/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/MeasurementUnit.kt
+++ b/app/src/main/java/com/github/se/polyfit/model/nutritionalInformation/MeasurementUnit.kt
@@ -88,7 +88,8 @@ enum class MeasurementUnit {
     fun unitConversion(from: MeasurementUnit, to: MeasurementUnit, value: Double): Double {
       if (from == UNIT || to == UNIT || from == OTHER || to == OTHER) {
         Log.e("MeasurementUnit", "Unsupported conversion from $from to $to")
-        throw IllegalArgumentException("Unsupported conversion from $from to $to")
+        //        throw IllegalArgumentException("Unsupported conversion from $from to $to")
+        return value
       } else if (value < 0) {
         Log.e("MeasurementUnit", "Value cannot be negative")
         throw IllegalArgumentException("Value cannot be negative")

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/GraphScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/GraphScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import co.yml.charts.common.extensions.roundTwoDecimal
 import co.yml.charts.ui.linechart.LineChart
 import com.github.se.polyfit.R
 import com.github.se.polyfit.ui.components.DropDownMenu
@@ -139,13 +140,13 @@ private fun ListOfElements(filteredGraphData: List<GraphData>, modifier: Modifie
             Column(
                 horizontalAlignment = Alignment.Start, modifier = Modifier.padding(start = 4.dp)) {
                   Text(
-                      text = context.getString(R.string.kcalvalue, data.kCal),
+                      text = context.getString(R.string.kcalvalue, data.kCal.roundTwoDecimal()),
                       modifier = Modifier.testTag("kcal"))
                   Text(
                       text =
-                          context.getString(R.string.weightvalue, data.weight).takeIf {
-                            data.weight > 0.0
-                          } ?: "",
+                          context
+                              .getString(R.string.weightvalue, data.weight.roundTwoDecimal())
+                              .takeIf { data.weight > 0.0 } ?: "",
                       modifier = Modifier.testTag("weight"))
                 }
             Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
     <string name="condition4">"Privacy Policy"</string>
     <string name="signGoogle">"Sign in with Google"</string>
     <string name="graphScreenTitle">Calories Per Day</string>
-    <string name="kcalvalue">%1$.1f kCal</string>
-    <string name="weightvalue">%1$.1f g</string>
+    <string name="kcalvalue">%1$.2f kCal</string>
+    <string name="weightvalue">%1$.2f g</string>
     <string name="datevalue">%1$s</string>
     <string name="noPostAvailable">"Unfortunately there is no post\navailable around you"</string>
     <string name="description">"Description"</string>

--- a/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/MeasurementUnitTest.kt
+++ b/app/src/test/java/com/github/se/polyfit/model/nutritionalInformation/MeasurementUnitTest.kt
@@ -5,7 +5,6 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import junit.framework.TestCase.assertEquals
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 import org.junit.Before
 
 class MeasurementUnitTest {
@@ -61,12 +60,5 @@ class MeasurementUnitTest {
   @Test
   fun `illegal arguments throw exception`() {
     assertEquals(MeasurementUnit.fromString("INVALID"), MeasurementUnit.OTHER)
-  }
-
-  @Test
-  fun `test UNIT conversion`() {
-    assertFailsWith<IllegalArgumentException> {
-      MeasurementUnit.unitConversion(MeasurementUnit.UNIT, MeasurementUnit.UNIT, 1.0)
-    }
   }
 }


### PR DESCRIPTION
Fixing small bug that caused number of calories or weight with big decimal to make the app crash when attempted to be displayed