### PR TITLE
Prevent users from having their birthday set in the future

### DIFF
--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/DateSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/DateSelector.kt
@@ -35,6 +35,7 @@ fun DateSelector(
     onConfirm: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
     title: String = "",
+    allowFutureDates: Boolean = true,
     inputDate: LocalDate? = null,
     titleStyle: TextStyle = MaterialTheme.typography.titleLarge,
 ) {
@@ -43,9 +44,10 @@ fun DateSelector(
   val startDate = inputDate ?: LocalDate.now(ZoneId.systemDefault())
   val initialMillis = startDate.toEpochDay() * 1000 * 60 * 60 * 24
   val datePickerState = rememberDatePickerState(initialSelectedDateMillis = initialMillis)
-
   val selectedDate =
       LocalDate.ofEpochDay(datePickerState.selectedDateMillis!! / (1000 * 60 * 60 * 24))
+  val invalidSelection =
+      !allowFutureDates && selectedDate.isAfter(LocalDate.now(ZoneId.systemDefault()))
 
   fun onConfirm() {
     onConfirm(selectedDate)
@@ -72,7 +74,11 @@ fun DateSelector(
           if (showDatePicker) {
             DatePickerDialog(
                 onDismissRequest = { showDatePicker = false },
-                confirmButton = { TextButton(onClick = { onConfirm() }) { Text(text = "Done") } },
+                confirmButton = {
+                  TextButton(enabled = !invalidSelection, onClick = { onConfirm() }) {
+                    Text(text = "Done")
+                  }
+                },
                 dismissButton = {
                   TextButton(onClick = { showDatePicker = false }) { Text(text = "Cancel") }
                 },

--- a/app/src/main/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
@@ -175,7 +175,8 @@ private fun AccountSettings(
           title = getString(context, R.string.accountSettingsDob),
           titleStyle = MaterialTheme.typography.titleMedium,
           inputDate = user.dob,
-          modifier = Modifier.padding(vertical = 8.dp))
+          modifier = Modifier.padding(vertical = 8.dp),
+          allowFutureDates = false)
     }
 
     // TODO: Add interface to set dietary preferences


### PR DESCRIPTION
From the feedback we received in Sprint 9 retro, we should block users from setting birthdays in the future.

I added an extra default parameter to the date selector such that if the user passes the non-default value, users can not select a date in the future.