### PR TITLE
Fix the squished circle for nutrients

### DIFF
--- a/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/components/selector/MealSelector.kt
@@ -1,8 +1,11 @@
 package com.github.se.polyfit.ui.components.selector
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -107,6 +110,7 @@ fun MealSelector(
   }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MealDetails(meal: Meal, modifier: Modifier = Modifier) {
   Box(modifier = modifier.fillMaxWidth().testTag("MealDetails")) {
@@ -135,31 +139,33 @@ fun MealDetails(meal: Meal, modifier: Modifier = Modifier) {
 
       Spacer(modifier = Modifier.height(10.dp))
 
-      Row(modifier = Modifier.align(Alignment.CenterHorizontally)) {
-        val macros = meal.getMacros()
-        val nutrients =
-            listOf(
-                Pair("Carbs", macros["carbohydrates"]),
-                Pair("Fat", macros["fat"]),
-                Pair("Protein", macros["protein"]),
-            )
+      FlowRow(
+          horizontalArrangement = Arrangement.Center,
+          modifier = Modifier.align(Alignment.CenterHorizontally)) {
+            val macros = meal.getMacros()
+            val nutrients =
+                listOf(
+                    Pair("Carbs", macros["carbohydrates"]),
+                    Pair("Fat", macros["fat"]),
+                    Pair("Protein", macros["protein"]),
+                )
 
-        nutrients.forEach { (nutrientName, amount) ->
-          GradientBox(
-              outerModifier = Modifier.padding(horizontal = 10.dp),
-              innerModifier = Modifier.size(80.dp),
-              round = 50.0) {
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                  Column(
-                      horizontalAlignment = Alignment.CenterHorizontally,
-                      modifier = Modifier.testTag(nutrientName)) {
-                        Text(text = "${amount!!.roundTwoDecimal()} g", color = SecondaryGrey)
-                        Text(text = nutrientName, color = PrimaryPurple, fontSize = 15.sp)
-                      }
-                }
-              }
-        }
-      }
+            nutrients.forEach { (nutrientName, amount) ->
+              GradientBox(
+                  outerModifier = Modifier.padding(8.dp),
+                  innerModifier = Modifier.size(80.dp),
+                  round = 50.0) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                      Column(
+                          horizontalAlignment = Alignment.CenterHorizontally,
+                          modifier = Modifier.testTag(nutrientName)) {
+                            Text(text = "${amount!!.roundTwoDecimal()} g", color = SecondaryGrey)
+                            Text(text = nutrientName, color = PrimaryPurple, fontSize = 15.sp)
+                          }
+                    }
+                  }
+            }
+          }
     }
   }
 }


### PR DESCRIPTION
When making a post, if the screen is too small the circle gets squished

Before:
<img width="158" alt="Screenshot 2024-05-27 at 5 24 12 PM" src="https://github.com/swent-group10/polyfit/assets/72662164/c211d2b8-4bf7-4588-bb06-a393ecb1b8c1">


Results:
<img width="158" alt="PNG image" src="https://github.com/swent-group10/polyfit/assets/72662164/256046e4-62bd-4cbd-bb65-b72930e5895f"> <img width="158" alt="PNG image" src="https://github.com/swent-group10/polyfit/assets/72662164/10c29c53-4fc0-4ea9-8e65-56deaaf821ff">
