### PR TITLE
Large username causes the app to crash

### DIFF
--- a/app/src/main/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/github/se/polyfit/ui/screen/settings/AccountSettingsScreen.kt
@@ -83,7 +83,11 @@ private fun AccountSettings(
           value = user.displayName ?: "",
           placeholder = { Text(getString(context, R.string.accountSettingsDisplayName)) },
           label = { Text(getString(context, R.string.accountSettingsDisplayName)) },
-          onValueChange = accountSettingsViewModel::updateDisplayName,
+          onValueChange = { newUsername ->
+            if (newUsername.length <= 20) {
+              accountSettingsViewModel.updateDisplayName(newUsername)
+            }
+          },
           singleLine = true,
           modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("DisplayName"))
     }


### PR DESCRIPTION
## Bugfix

**Issue:** When the user chooses a large username, it affects the placement of the composable on the overview screen and can sometimes cause the app to crash.

**Resolution:** To fix this, the username is now set to have a maximum of 20 characters.
